### PR TITLE
Implement skillsmith core

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,15 +11,60 @@ skillsmith
 [license]: https://github.com/Songmu/skillsmith/blob/main/LICENSE
 [PkgGoDev]: https://pkg.go.dev/github.com/Songmu/skillsmith
 
-skillsmith short description
+Ship embedded agent skills with your Go CLI.
 
 ## Synopsis
 
 ```go
-// simple usage here
+//go:embed skills/**
+var skillsFS embed.FS
+
+func run(ctx context.Context, args []string) error {
+    if len(args) > 0 && args[0] == "skills" {
+        sub, _ := fs.Sub(skillsFS, "skills")
+        s := &skillsmith.Smith{
+            FS:      sub,
+            Version: version,
+            Name:    "mytool",
+        }
+        return s.Run(ctx, args[1:])
+    }
+    // ... existing command handling
+    return nil
+}
 ```
 
 ## Description
+
+`skillsmith` is a Go library that makes it easy to attach
+[agentskills](https://agentskills.io/specification)-compatible skill
+distribution to any existing CLI tool.
+
+Embed a `skills/` directory into your binary using `embed.FS`, then expose a
+`skills` subcommand backed by `skillsmith.Smith`. Users can then install,
+update, and manage your tool's agent skills with commands like:
+
+```bash
+mytool skills list
+mytool skills install
+mytool skills install --dry-run
+mytool skills install --agent codex --scope user
+mytool skills status
+mytool skills update
+mytool skills reinstall
+mytool skills uninstall
+```
+
+### Key features
+
+- **No CLI framework dependency** — uses the standard `flag` package only.
+- **`embed.FS` / `fs.FS` throughout** — easy to test and embed.
+- **Lenient validation** — warns about name mismatches; only skips skills with
+  missing descriptions or unparseable YAML.
+- **Metadata tracking** — writes `.skillsmith.json` alongside each installed
+  skill so that `update` and `reinstall` work correctly.
+- **`agentskill` subpackage** — SKILL.md parsing and discovery can be used
+  independently of the CLI layer.
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -48,12 +48,17 @@ update, and manage your tool's agent skills with commands like:
 mytool skills list
 mytool skills install
 mytool skills install --dry-run
-mytool skills install --agent codex --scope user
+mytool skills install --scope user
+mytool skills install --prefix ~/.agents/skills
 mytool skills status
 mytool skills update
 mytool skills reinstall
 mytool skills uninstall
 ```
+
+By default, skills are installed into `~/.agents/skills`. You can override this
+location with `--prefix`, control the target scope with `--scope`, and use
+`--dry-run` or `--force` to preview or force installations.
 
 ### Key features
 

--- a/SKETCH.md
+++ b/SKETCH.md
@@ -118,7 +118,7 @@ func run(ctx context.Context, args []string) error {
 mytool skills list
 mytool skills install
 mytool skills install --dry-run
-mytool skills install --dir ~/.codex/skills
+mytool skills install --prefix ~/.codex/skills
 mytool skills install --agent codex --scope user
 mytool skills status
 mytool skills update
@@ -130,7 +130,7 @@ mytool skills uninstall
 | オプション | 短縮 | 概要 |
 |-----------|------|------|
 | `--dry-run` | | 実際の変更を行わず、何が行われるかを表示する |
-| `--dir` | | インストール先ディレクトリを直接指定 |
+| `--prefix` | | スキルのインストール先ディレクトリを直接指定 |
 | `--agent` | | 対象 agent（`codex`, `claude`, `agents`） |
 | `--scope` | | 対象スコープ（`user`, `repo`） |
 | `--force` | | 管理外スキルの上書きを許可 |
@@ -162,9 +162,13 @@ mytool skills uninstall
 
 ### 解決の優先順位
 
-1. `--dir` — 指定時は Agent / Scope の解決を行わない
+1. `--prefix` — 指定時は Agent / Scope の解決を行わない
 2. `--agent` + `--scope`
 3. ライブラリ既定値: `claude` + `user`（→ `~/.claude/skills`）
+
+### 将来検討
+
+- スキルの別名インストール
 
 
 ## ファイルコピー方針

--- a/SKETCH.md
+++ b/SKETCH.md
@@ -119,6 +119,7 @@ mytool skills list
 mytool skills install
 mytool skills install --dry-run
 mytool skills install --prefix ~/.codex/skills
+mytool skills install --scope repo
 mytool skills status
 mytool skills update
 mytool skills uninstall
@@ -129,7 +130,8 @@ mytool skills uninstall
 | オプション | 短縮 | 概要 |
 |-----------|------|------|
 | `--dry-run` | | 実際の変更を行わず、何が行われるかを表示する |
-| `--prefix` | | スキルのインストール先ディレクトリを直接指定（既定: `~/.agents/skills`） |
+| `--prefix` | | スキルのインストール先ディレクトリを直接指定（指定時は `--scope` を無視） |
+| `--scope` | | `user`（既定: `~/.agents/skills`）または `repo`（`.agents/skills`） |
 | `--force` | | 管理外スキルの上書きを許可 |
 | `--help` | `-h` | ヘルプを表示 |
 
@@ -147,8 +149,9 @@ mytool skills uninstall
 
 ### 解決の優先順位
 
-1. `--prefix <dir>` — 指定時はその値を使用する
-2. 既定値: `~/.agents/skills`
+1. `--prefix <dir>` — 指定時はその値を使用する（`--scope` は無視される）
+2. `--scope repo` — `.agents/skills`（カレントディレクトリ基準）
+3. `--scope user`（または指定なし） — `~/.agents/skills`
 
 ### 将来検討
 

--- a/SKETCH.md
+++ b/SKETCH.md
@@ -58,7 +58,7 @@ skills/
 3. **Skill 配布層**
    - `embed.FS` または任意の `fs.FS` から skill ディレクトリを列挙・コピーする
 4. **インストール先解決層**
-   - `--dir` / `--agent` / `--scope` から配置先を決定する
+   - `--prefix` または既定値（`~/.agents/skills`）から配置先を決定する
 5. **SKILL.md パース・バリデーション層**
    - agentskills 仕様に基づく SKILL.md の frontmatter パース・バリデーション
    - サブパッケージとして切り出し、skillsmith 外でも利用可能にする
@@ -119,7 +119,6 @@ mytool skills list
 mytool skills install
 mytool skills install --dry-run
 mytool skills install --prefix ~/.codex/skills
-mytool skills install --agent codex --scope user
 mytool skills status
 mytool skills update
 mytool skills uninstall
@@ -130,9 +129,7 @@ mytool skills uninstall
 | オプション | 短縮 | 概要 |
 |-----------|------|------|
 | `--dry-run` | | 実際の変更を行わず、何が行われるかを表示する |
-| `--prefix` | | スキルのインストール先ディレクトリを直接指定 |
-| `--agent` | | 対象 agent（`codex`, `claude`, `agents`） |
-| `--scope` | | 対象スコープ（`user`, `repo`） |
+| `--prefix` | | スキルのインストール先ディレクトリを直接指定（既定: `~/.agents/skills`） |
 | `--force` | | 管理外スキルの上書きを許可 |
 | `--help` | `-h` | ヘルプを表示 |
 
@@ -146,25 +143,12 @@ mytool skills uninstall
 
 ## インストール先解決
 
-### Agent / Scope のパスマッピング
-
-| Agent | Scope | パス |
-|-------|-------|------|
-| `codex` | `user` | `~/.codex/skills` |
-| `codex` | `repo` | `.agents/skills` |
-| `claude` | `user` | `~/.claude/skills` |
-| `claude` | `repo` | `.claude/skills` |
-| `agents` | `user` | `~/.agents/skills` |
-| `agents` | `repo` | `.agents/skills` |
-
-- `claude`: Claude Code と GitHub Copilot の両方をカバー（Copilot も `.claude/skills` を読む）
-- `agents`: agentskills 仕様のクロスクライアント互換パス
+`.agents/skills` は agentskills のクロスクライアント標準パスである。
 
 ### 解決の優先順位
 
-1. `--prefix` — 指定時は Agent / Scope の解決を行わない
-2. `--agent` + `--scope`
-3. ライブラリ既定値: `claude` + `user`（→ `~/.claude/skills`）
+1. `--prefix <dir>` — 指定時はその値を使用する
+2. 既定値: `~/.agents/skills`
 
 ### 将来検討
 

--- a/agentskill/discover.go
+++ b/agentskill/discover.go
@@ -18,15 +18,16 @@ import (
 //	    SKILL.md
 //
 // Skills whose SKILL.md cannot be parsed or fails validation are omitted from
-// the returned slice; a descriptive error is appended to the returned error
-// slice instead.
-func Discover(fsys fs.FS) ([]Skill, []error) {
+// the returned slice; each such failure is collected into the returned error as
+// a [SkillError] (joined via [errors.Join]) so callers can use [errors.As] to
+// retrieve per-skill directory information.
+func Discover(fsys fs.FS) ([]*Skill, error) {
 	entries, err := fs.ReadDir(fsys, ".")
 	if err != nil {
-		return nil, []error{fmt.Errorf("discover: reading root directory: %w", err)}
+		return nil, fmt.Errorf("discover: reading root directory: %w", err)
 	}
 
-	var skills []Skill
+	var skills []*Skill
 	var errs []error
 
 	for _, entry := range entries {
@@ -42,29 +43,29 @@ func Discover(fsys fs.FS) ([]Skill, []error) {
 			if errors.Is(err, fs.ErrNotExist) {
 				continue
 			}
-			// Other I/O errors are recorded as non-fatal discovery errors.
-			errs = append(errs, fmt.Errorf("discover: %s: open error: %w", skillPath, err))
+			// Other I/O errors are recorded as non-fatal per-skill errors.
+			errs = append(errs, &SkillError{Dir: dirName, Err: fmt.Errorf("open error: %w", err)})
 			continue
 		}
 
 		skill, err := Parse(f)
 		f.Close() //nolint:errcheck
 		if err != nil {
-			errs = append(errs, fmt.Errorf("discover: %s: parse error: %w", skillPath, err))
+			errs = append(errs, &SkillError{Dir: dirName, Err: fmt.Errorf("parse error: %w", err)})
 			continue
 		}
 
 		result := Validate(skill, dirName)
 		if !result.OK() {
 			for _, e := range result.Errors {
-				errs = append(errs, fmt.Errorf("discover: %s: validation error: %s", skillPath, e))
+				errs = append(errs, &SkillError{Dir: dirName, Err: fmt.Errorf("validation error: %s", e)})
 			}
 			continue
 		}
 
 		skill.Dir = dirName
-		skills = append(skills, *skill)
+		skills = append(skills, skill)
 	}
 
-	return skills, errs
+	return skills, errors.Join(errs...)
 }

--- a/agentskill/discover.go
+++ b/agentskill/discover.go
@@ -1,6 +1,7 @@
 package agentskill
 
 import (
+	"errors"
 	"fmt"
 	"io/fs"
 	"path"
@@ -38,6 +39,11 @@ func Discover(fsys fs.FS) ([]Skill, []error) {
 		f, err := fsys.Open(skillPath)
 		if err != nil {
 			// No SKILL.md in this directory — silently skip.
+			if errors.Is(err, fs.ErrNotExist) {
+				continue
+			}
+			// Other I/O errors are recorded as non-fatal discovery errors.
+			errs = append(errs, fmt.Errorf("discover: %s: open error: %w", skillPath, err))
 			continue
 		}
 

--- a/agentskill/discover.go
+++ b/agentskill/discover.go
@@ -1,0 +1,64 @@
+package agentskill
+
+import (
+	"fmt"
+	"io/fs"
+	"path"
+)
+
+// Discover enumerates skill directories inside fsys, parses each SKILL.md,
+// and returns the valid skills together with any non-fatal errors encountered.
+//
+// The top-level directory in fsys is expected to contain skill subdirectories,
+// for example:
+//
+//	skills/
+//	  mytool-cli/
+//	    SKILL.md
+//
+// Skills whose SKILL.md cannot be parsed or fails validation are omitted from
+// the returned slice; a descriptive error is appended to the returned error
+// slice instead.
+func Discover(fsys fs.FS) ([]Skill, []error) {
+	entries, err := fs.ReadDir(fsys, ".")
+	if err != nil {
+		return nil, []error{fmt.Errorf("discover: reading root directory: %w", err)}
+	}
+
+	var skills []Skill
+	var errs []error
+
+	for _, entry := range entries {
+		if !entry.IsDir() {
+			continue
+		}
+		dirName := entry.Name()
+		skillPath := path.Join(dirName, "SKILL.md")
+
+		f, err := fsys.Open(skillPath)
+		if err != nil {
+			// No SKILL.md in this directory — silently skip.
+			continue
+		}
+
+		skill, err := Parse(f)
+		f.Close() //nolint:errcheck
+		if err != nil {
+			errs = append(errs, fmt.Errorf("discover: %s: parse error: %w", skillPath, err))
+			continue
+		}
+
+		result := Validate(skill, dirName)
+		if !result.OK() {
+			for _, e := range result.Errors {
+				errs = append(errs, fmt.Errorf("discover: %s: validation error: %s", skillPath, e))
+			}
+			continue
+		}
+
+		skill.Dir = dirName
+		skills = append(skills, *skill)
+	}
+
+	return skills, errs
+}

--- a/agentskill/discover_test.go
+++ b/agentskill/discover_test.go
@@ -1,6 +1,7 @@
 package agentskill
 
 import (
+	"errors"
 	"testing"
 	"testing/fstest"
 )
@@ -25,9 +26,9 @@ description: Another skill
 		},
 	}
 
-	skills, errs := Discover(fsys)
-	if len(errs) != 0 {
-		t.Errorf("unexpected errors: %v", errs)
+	skills, err := Discover(fsys)
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
 	}
 	if len(skills) != 2 {
 		t.Errorf("expected 2 skills, got %d", len(skills))
@@ -46,9 +47,9 @@ description: A skill
 		},
 	}
 
-	skills, errs := Discover(fsys)
-	if len(errs) != 0 {
-		t.Errorf("unexpected errors: %v", errs)
+	skills, err := Discover(fsys)
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
 	}
 	if len(skills) != 1 {
 		t.Errorf("expected 1 skill, got %d", len(skills))
@@ -63,9 +64,9 @@ func TestDiscover_SkipsNoSKILLmd(t *testing.T) {
 		"my-skill/README.md": {Data: []byte("hello")},
 	}
 
-	skills, errs := Discover(fsys)
-	if len(errs) != 0 {
-		t.Errorf("unexpected errors: %v", errs)
+	skills, err := Discover(fsys)
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
 	}
 	if len(skills) != 0 {
 		t.Errorf("expected 0 skills, got %d", len(skills))
@@ -86,9 +87,14 @@ description: A good skill
 		},
 	}
 
-	skills, errs := Discover(fsys)
-	if len(errs) == 0 {
+	skills, err := Discover(fsys)
+	if err == nil {
 		t.Error("expected at least one error for bad-skill, got none")
+	}
+	// The error should be extractable as a SkillError.
+	var se *SkillError
+	if !errors.As(err, &se) {
+		t.Errorf("expected *SkillError in error chain, got: %T %v", err, err)
 	}
 	if len(skills) != 1 || skills[0].Dir != "good-skill" {
 		t.Errorf("expected 1 valid skill (good-skill), got %v", skills)
@@ -106,9 +112,13 @@ description: ""
 		},
 	}
 
-	skills, errs := Discover(fsys)
-	if len(errs) == 0 {
+	skills, err := Discover(fsys)
+	if err == nil {
 		t.Error("expected error for missing description, got none")
+	}
+	var se *SkillError
+	if !errors.As(err, &se) {
+		t.Errorf("expected *SkillError in error chain, got: %T %v", err, err)
 	}
 	if len(skills) != 0 {
 		t.Errorf("expected 0 skills, got %d", len(skills))
@@ -126,9 +136,9 @@ description: A skill
 		},
 	}
 
-	skills, errs := Discover(fsys)
-	if len(errs) != 0 {
-		t.Errorf("unexpected errors: %v", errs)
+	skills, err := Discover(fsys)
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
 	}
 	if len(skills) != 1 {
 		t.Errorf("expected 1 skill (warning should not skip), got %d", len(skills))

--- a/agentskill/discover_test.go
+++ b/agentskill/discover_test.go
@@ -1,0 +1,136 @@
+package agentskill
+
+import (
+	"testing"
+	"testing/fstest"
+)
+
+func TestDiscover_Valid(t *testing.T) {
+	fsys := fstest.MapFS{
+		"mytool-cli/SKILL.md": {
+			Data: []byte(`---
+name: mytool-cli
+description: A CLI skill
+license: MIT
+---
+body
+`),
+		},
+		"other-tool/SKILL.md": {
+			Data: []byte(`---
+name: other-tool
+description: Another skill
+---
+`),
+		},
+	}
+
+	skills, errs := Discover(fsys)
+	if len(errs) != 0 {
+		t.Errorf("unexpected errors: %v", errs)
+	}
+	if len(skills) != 2 {
+		t.Errorf("expected 2 skills, got %d", len(skills))
+	}
+}
+
+func TestDiscover_SkipsNonDirs(t *testing.T) {
+	fsys := fstest.MapFS{
+		"README.md": {Data: []byte("hello")},
+		"my-skill/SKILL.md": {
+			Data: []byte(`---
+name: my-skill
+description: A skill
+---
+`),
+		},
+	}
+
+	skills, errs := Discover(fsys)
+	if len(errs) != 0 {
+		t.Errorf("unexpected errors: %v", errs)
+	}
+	if len(skills) != 1 {
+		t.Errorf("expected 1 skill, got %d", len(skills))
+	}
+	if skills[0].Dir != "my-skill" {
+		t.Errorf("Dir = %q, want %q", skills[0].Dir, "my-skill")
+	}
+}
+
+func TestDiscover_SkipsNoSKILLmd(t *testing.T) {
+	fsys := fstest.MapFS{
+		"my-skill/README.md": {Data: []byte("hello")},
+	}
+
+	skills, errs := Discover(fsys)
+	if len(errs) != 0 {
+		t.Errorf("unexpected errors: %v", errs)
+	}
+	if len(skills) != 0 {
+		t.Errorf("expected 0 skills, got %d", len(skills))
+	}
+}
+
+func TestDiscover_ParseError(t *testing.T) {
+	fsys := fstest.MapFS{
+		"bad-skill/SKILL.md": {
+			Data: []byte("no frontmatter here"),
+		},
+		"good-skill/SKILL.md": {
+			Data: []byte(`---
+name: good-skill
+description: A good skill
+---
+`),
+		},
+	}
+
+	skills, errs := Discover(fsys)
+	if len(errs) == 0 {
+		t.Error("expected at least one error for bad-skill, got none")
+	}
+	if len(skills) != 1 || skills[0].Dir != "good-skill" {
+		t.Errorf("expected 1 valid skill (good-skill), got %v", skills)
+	}
+}
+
+func TestDiscover_ValidationError(t *testing.T) {
+	fsys := fstest.MapFS{
+		"no-desc/SKILL.md": {
+			Data: []byte(`---
+name: no-desc
+description: ""
+---
+`),
+		},
+	}
+
+	skills, errs := Discover(fsys)
+	if len(errs) == 0 {
+		t.Error("expected error for missing description, got none")
+	}
+	if len(skills) != 0 {
+		t.Errorf("expected 0 skills, got %d", len(skills))
+	}
+}
+
+func TestDiscover_WarningDoesNotSkip(t *testing.T) {
+	fsys := fstest.MapFS{
+		"my-skill/SKILL.md": {
+			Data: []byte(`---
+name: different-name
+description: A skill
+---
+`),
+		},
+	}
+
+	skills, errs := Discover(fsys)
+	if len(errs) != 0 {
+		t.Errorf("unexpected errors: %v", errs)
+	}
+	if len(skills) != 1 {
+		t.Errorf("expected 1 skill (warning should not skip), got %d", len(skills))
+	}
+}

--- a/agentskill/error.go
+++ b/agentskill/error.go
@@ -1,0 +1,19 @@
+package agentskill
+
+import "fmt"
+
+// SkillError is an error associated with a specific skill directory.
+// It is returned (potentially wrapped in a joined error) by [Discover].
+// Callers can use [errors.As] to extract the Dir field.
+type SkillError struct {
+	Dir string
+	Err error
+}
+
+func (e *SkillError) Error() string {
+	return fmt.Sprintf("%s: %v", e.Dir, e.Err)
+}
+
+func (e *SkillError) Unwrap() error {
+	return e.Err
+}

--- a/agentskill/skill.go
+++ b/agentskill/skill.go
@@ -1,0 +1,108 @@
+package agentskill
+
+import (
+	"bufio"
+	"bytes"
+	"errors"
+	"io"
+	"strings"
+
+	"github.com/goccy/go-yaml"
+)
+
+// Skill represents a parsed agentskill from a SKILL.md file.
+type Skill struct {
+	// Name is the skill name from frontmatter.
+	Name string
+	// Description is the skill description from frontmatter.
+	Description string
+	// License is the SPDX license identifier from frontmatter.
+	License string
+	// Compatibility lists agent compatibility strings from frontmatter.
+	Compatibility []string
+	// Metadata holds arbitrary client-extension metadata from frontmatter.
+	Metadata map[string]any
+	// AllowedTools lists permitted tool names from frontmatter.
+	AllowedTools []string
+	// Body is the Markdown body after the closing frontmatter delimiter.
+	Body string
+	// Dir is the directory name of the skill (set by Discover).
+	Dir string
+}
+
+// frontmatter holds the raw YAML fields parsed from the SKILL.md header.
+type frontmatter struct {
+	Name          string         `yaml:"name"`
+	Description   string         `yaml:"description"`
+	License       string         `yaml:"license"`
+	Compatibility []string       `yaml:"compatibility"`
+	Metadata      map[string]any `yaml:"metadata"`
+	AllowedTools  []string       `yaml:"allowed_tools"`
+}
+
+// Parse reads a SKILL.md file from r and returns a Skill.
+// It returns an error when the YAML frontmatter is unparseable or missing.
+func Parse(r io.Reader) (*Skill, error) {
+	data, err := io.ReadAll(r)
+	if err != nil {
+		return nil, err
+	}
+
+	// Extract YAML frontmatter between the first pair of "---" delimiters.
+	yamlBytes, body, err := splitFrontmatter(data)
+	if err != nil {
+		return nil, err
+	}
+
+	var fm frontmatter
+	if err := yaml.Unmarshal(yamlBytes, &fm); err != nil {
+		return nil, err
+	}
+
+	s := &Skill{
+		Name:          fm.Name,
+		Description:   fm.Description,
+		License:       fm.License,
+		Compatibility: fm.Compatibility,
+		Metadata:      fm.Metadata,
+		AllowedTools:  fm.AllowedTools,
+		Body:          body,
+	}
+	return s, nil
+}
+
+// splitFrontmatter splits the raw content of a SKILL.md into the YAML bytes
+// (without delimiters) and the remaining body text.
+// It returns an error when no valid frontmatter block is found.
+func splitFrontmatter(data []byte) (yamlBytes []byte, body string, err error) {
+	scanner := bufio.NewScanner(bytes.NewReader(data))
+
+	var lines []string
+	for scanner.Scan() {
+		lines = append(lines, scanner.Text())
+	}
+	if scanErr := scanner.Err(); scanErr != nil {
+		return nil, "", scanErr
+	}
+
+	if len(lines) == 0 || strings.TrimSpace(lines[0]) != "---" {
+		return nil, "", errors.New("SKILL.md: missing frontmatter opening delimiter")
+	}
+
+	// Find the closing "---".
+	closingIdx := -1
+	for i := 1; i < len(lines); i++ {
+		if strings.TrimSpace(lines[i]) == "---" {
+			closingIdx = i
+			break
+		}
+	}
+	if closingIdx < 0 {
+		return nil, "", errors.New("SKILL.md: missing frontmatter closing delimiter")
+	}
+
+	yamlContent := strings.Join(lines[1:closingIdx], "\n")
+	bodyContent := strings.Join(lines[closingIdx+1:], "\n")
+
+	return []byte(yamlContent), strings.TrimLeft(bodyContent, "\n"), nil
+}

--- a/agentskill/skill.go
+++ b/agentskill/skill.go
@@ -94,5 +94,5 @@ func splitFrontmatter(data []byte) (yamlBytes []byte, body string, err error) {
 	yamlContent := strings.Join(lines[1:closingIdx], "\n")
 	bodyContent := strings.Join(lines[closingIdx+1:], "\n")
 
-	return []byte(yamlContent), strings.TrimLeft(bodyContent, "\n"), nil
+	return []byte(yamlContent), strings.TrimLeft(bodyContent, "\r\n"), nil
 }

--- a/agentskill/skill.go
+++ b/agentskill/skill.go
@@ -1,8 +1,6 @@
 package agentskill
 
 import (
-	"bufio"
-	"bytes"
 	"errors"
 	"io"
 	"strings"
@@ -75,15 +73,7 @@ func Parse(r io.Reader) (*Skill, error) {
 // (without delimiters) and the remaining body text.
 // It returns an error when no valid frontmatter block is found.
 func splitFrontmatter(data []byte) (yamlBytes []byte, body string, err error) {
-	scanner := bufio.NewScanner(bytes.NewReader(data))
-
-	var lines []string
-	for scanner.Scan() {
-		lines = append(lines, scanner.Text())
-	}
-	if scanErr := scanner.Err(); scanErr != nil {
-		return nil, "", scanErr
-	}
+	lines := strings.Split(string(data), "\n")
 
 	if len(lines) == 0 || strings.TrimSpace(lines[0]) != "---" {
 		return nil, "", errors.New("SKILL.md: missing frontmatter opening delimiter")

--- a/agentskill/skill_test.go
+++ b/agentskill/skill_test.go
@@ -1,0 +1,101 @@
+package agentskill
+
+import (
+	"strings"
+	"testing"
+)
+
+const validSKILL = `---
+name: mytool-cli
+description: A helpful CLI skill
+license: MIT
+compatibility:
+  - claude
+  - codex
+allowed_tools:
+  - Bash
+---
+
+# mytool-cli
+
+This skill teaches AI agents how to use mytool-cli effectively.
+`
+
+func TestParse_Valid(t *testing.T) {
+	s, err := Parse(strings.NewReader(validSKILL))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if s.Name != "mytool-cli" {
+		t.Errorf("Name = %q, want %q", s.Name, "mytool-cli")
+	}
+	if s.Description != "A helpful CLI skill" {
+		t.Errorf("Description = %q, want %q", s.Description, "A helpful CLI skill")
+	}
+	if s.License != "MIT" {
+		t.Errorf("License = %q, want %q", s.License, "MIT")
+	}
+	if len(s.Compatibility) != 2 || s.Compatibility[0] != "claude" {
+		t.Errorf("Compatibility = %v, want [claude codex]", s.Compatibility)
+	}
+	if len(s.AllowedTools) != 1 || s.AllowedTools[0] != "Bash" {
+		t.Errorf("AllowedTools = %v, want [Bash]", s.AllowedTools)
+	}
+	if !strings.Contains(s.Body, "mytool-cli") {
+		t.Errorf("Body does not contain expected content, got: %q", s.Body)
+	}
+}
+
+func TestParse_MissingOpeningDelimiter(t *testing.T) {
+	_, err := Parse(strings.NewReader("name: foo\ndescription: bar\n"))
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+}
+
+func TestParse_MissingClosingDelimiter(t *testing.T) {
+	_, err := Parse(strings.NewReader("---\nname: foo\ndescription: bar\n"))
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+}
+
+func TestParse_InvalidYAML(t *testing.T) {
+	_, err := Parse(strings.NewReader("---\n: invalid: yaml: [\n---\n"))
+	if err == nil {
+		t.Fatal("expected error for invalid YAML, got nil")
+	}
+}
+
+func TestParse_EmptyBody(t *testing.T) {
+	input := "---\nname: foo\ndescription: bar\n---\n"
+	s, err := Parse(strings.NewReader(input))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if s.Body != "" {
+		t.Errorf("Body = %q, want empty string", s.Body)
+	}
+}
+
+func TestParse_WithMetadata(t *testing.T) {
+	input := `---
+name: foo
+description: bar
+metadata:
+  key: value
+  num: 42
+---
+body
+`
+	s, err := Parse(strings.NewReader(input))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if s.Metadata == nil {
+		t.Fatal("Metadata is nil, want map")
+	}
+	if s.Metadata["key"] != "value" {
+		t.Errorf("Metadata[key] = %v, want \"value\"", s.Metadata["key"])
+	}
+}

--- a/agentskill/validate.go
+++ b/agentskill/validate.go
@@ -1,0 +1,39 @@
+package agentskill
+
+import "fmt"
+
+// ValidationResult holds the warnings and errors produced by Validate.
+type ValidationResult struct {
+	Warnings []string
+	Errors   []string
+}
+
+// OK reports whether there are no errors (warnings are allowed).
+func (v *ValidationResult) OK() bool {
+	return len(v.Errors) == 0
+}
+
+// Validate performs lenient validation of a Skill against its directory name.
+// Warnings do not prevent installation; errors cause the skill to be skipped.
+func Validate(s *Skill, dirName string) *ValidationResult {
+	result := &ValidationResult{}
+
+	// description empty/missing → Error (skip skill)
+	if s.Description == "" {
+		result.Errors = append(result.Errors, "description is empty or missing")
+	}
+
+	// name mismatch with directory → Warning (not error)
+	if s.Name != "" && dirName != "" && s.Name != dirName {
+		result.Warnings = append(result.Warnings,
+			fmt.Sprintf("skill name %q does not match directory name %q", s.Name, dirName))
+	}
+
+	// name > 64 chars → Warning
+	if len(s.Name) > 64 {
+		result.Warnings = append(result.Warnings,
+			fmt.Sprintf("skill name %q exceeds 64 characters", s.Name))
+	}
+
+	return result
+}

--- a/agentskill/validate_test.go
+++ b/agentskill/validate_test.go
@@ -1,0 +1,56 @@
+package agentskill
+
+import "testing"
+
+func TestValidate_Valid(t *testing.T) {
+	s := &Skill{Name: "foo", Description: "some description"}
+	result := Validate(s, "foo")
+	if !result.OK() {
+		t.Errorf("expected OK, got errors: %v", result.Errors)
+	}
+	if len(result.Warnings) != 0 {
+		t.Errorf("expected no warnings, got: %v", result.Warnings)
+	}
+}
+
+func TestValidate_EmptyDescription(t *testing.T) {
+	s := &Skill{Name: "foo", Description: ""}
+	result := Validate(s, "foo")
+	if result.OK() {
+		t.Error("expected error for empty description, got OK")
+	}
+}
+
+func TestValidate_NameMismatch(t *testing.T) {
+	s := &Skill{Name: "other-name", Description: "some description"}
+	result := Validate(s, "foo")
+	if !result.OK() {
+		t.Errorf("expected OK (name mismatch is a warning), got errors: %v", result.Errors)
+	}
+	if len(result.Warnings) == 0 {
+		t.Error("expected warning for name mismatch, got none")
+	}
+}
+
+func TestValidate_NameTooLong(t *testing.T) {
+	longName := "a"
+	for i := 0; i < 64; i++ {
+		longName += "a"
+	}
+	s := &Skill{Name: longName, Description: "some description"}
+	result := Validate(s, longName)
+	if !result.OK() {
+		t.Errorf("expected OK (long name is a warning), got errors: %v", result.Errors)
+	}
+	if len(result.Warnings) == 0 {
+		t.Error("expected warning for long name, got none")
+	}
+}
+
+func TestValidate_NoNameNoDir(t *testing.T) {
+	s := &Skill{Name: "", Description: "desc"}
+	result := Validate(s, "")
+	if !result.OK() {
+		t.Errorf("expected OK, got errors: %v", result.Errors)
+	}
+}

--- a/cmd/skillsmith/main.go
+++ b/cmd/skillsmith/main.go
@@ -11,7 +11,23 @@ import (
 
 func main() {
 	log.SetFlags(0)
-	err := skillsmith.Run(context.Background(), os.Args[1:], os.Stdout, os.Stderr)
+
+	args := os.Args[1:]
+	if len(args) > 0 && args[0] == "skills" {
+		s := &skillsmith.Smith{
+			FS:      skillsmith.DemoFS(),
+			Version: skillsmith.Version(),
+			Name:    "skillsmith",
+		}
+		err := s.Run(context.Background(), args[1:])
+		if err != nil && err != flag.ErrHelp {
+			log.Println(err)
+			os.Exit(1)
+		}
+		return
+	}
+
+	err := skillsmith.Run(context.Background(), args, os.Stdout, os.Stderr)
 	if err != nil && err != flag.ErrHelp {
 		log.Println(err)
 		exitCode := 1

--- a/cmd_install.go
+++ b/cmd_install.go
@@ -39,7 +39,11 @@ func (s *Smith) cmdInstall(_ context.Context, args []string, out, errW io.Writer
 	for _, a := range result.Actions {
 		switch a.Action {
 		case "installed":
-			fmt.Fprintf(out, "installed: %s\n", a.Dir)
+			if cf.dryRun {
+				fmt.Fprintln(out, a.Message)
+			} else {
+				fmt.Fprintf(out, "installed: %s\n", a.Dir)
+			}
 		case "skipped":
 			fmt.Fprintf(out, "skipped:   %s — %s\n", a.Dir, a.Message)
 		case "warned":

--- a/cmd_install.go
+++ b/cmd_install.go
@@ -40,7 +40,7 @@ func (s *Smith) cmdInstall(_ context.Context, args []string, out, errW io.Writer
 		switch a.Action {
 		case "installed":
 			if cf.dryRun {
-				fmt.Fprintln(out, a.Message)
+				fmt.Fprintf(out, "installed (dry-run): %s\n", a.Dir)
 			} else {
 				fmt.Fprintf(out, "installed: %s\n", a.Dir)
 			}

--- a/cmd_install.go
+++ b/cmd_install.go
@@ -1,0 +1,54 @@
+package skillsmith
+
+import (
+	"context"
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+)
+
+func (s *Smith) cmdInstall(_ context.Context, args []string, out, errW io.Writer) error {
+	f := flag.NewFlagSet("install", flag.ContinueOnError)
+	f.SetOutput(errW)
+	var cf commonFlags
+	addCommonFlags(f, &cf)
+	if err := f.Parse(args); err != nil {
+		if errors.Is(err, flag.ErrHelp) {
+			return nil
+		}
+		return err
+	}
+
+	dir, err := s.installDir(cf)
+	if err != nil {
+		return err
+	}
+
+	result, err := CopySkills(s.FS, dir, CopyOptions{
+		Mode:    ModeInstall,
+		Force:   cf.force,
+		DryRun:  cf.dryRun,
+		Name:    s.Name,
+		Version: s.Version,
+	})
+	if err != nil {
+		return err
+	}
+
+	for _, a := range result.Actions {
+		switch a.Action {
+		case "installed":
+			fmt.Fprintf(out, "installed: %s\n", a.Dir)
+		case "skipped":
+			fmt.Fprintf(out, "skipped:   %s — %s\n", a.Dir, a.Message)
+		case "warned":
+			fmt.Fprintf(errW, "warning:   %s — %s\n", a.Dir, a.Message)
+		}
+	}
+
+	if cf.dryRun {
+		fmt.Fprintln(out, "[dry-run] no changes were made")
+	}
+	return nil
+}

--- a/cmd_list.go
+++ b/cmd_list.go
@@ -20,10 +20,10 @@ func (s *Smith) cmdList(_ context.Context, args []string, out, errW io.Writer) e
 		return err
 	}
 
-	skills, errs := agentskill.Discover(s.FS)
-	for _, e := range errs {
+	skills, discoverErr := agentskill.Discover(s.FS)
+	eachError(discoverErr, func(e error) {
 		fmt.Fprintf(errW, "warning: %v\n", e)
-	}
+	})
 
 	if len(skills) == 0 {
 		fmt.Fprintln(out, "no skills found")

--- a/cmd_list.go
+++ b/cmd_list.go
@@ -21,9 +21,21 @@ func (s *Smith) cmdList(_ context.Context, args []string, out, errW io.Writer) e
 	}
 
 	skills, discoverErr := agentskill.Discover(s.FS)
+	var fatalErr error
 	eachError(discoverErr, func(e error) {
-		fmt.Fprintf(errW, "warning: %v\n", e)
+		var se *agentskill.SkillError
+		if errors.As(e, &se) {
+			fmt.Fprintf(errW, "warning: %v\n", e)
+			return
+		}
+		// Treat non-*SkillError errors as fatal.
+		if fatalErr == nil {
+			fatalErr = e
+		}
 	})
+	if fatalErr != nil {
+		return fatalErr
+	}
 
 	if len(skills) == 0 {
 		fmt.Fprintln(out, "no skills found")

--- a/cmd_list.go
+++ b/cmd_list.go
@@ -1,0 +1,41 @@
+package skillsmith
+
+import (
+	"context"
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+
+	"github.com/Songmu/skillsmith/agentskill"
+)
+
+func (s *Smith) cmdList(_ context.Context, args []string, out, errW io.Writer) error {
+	f := flag.NewFlagSet("list", flag.ContinueOnError)
+	f.SetOutput(errW)
+	if err := f.Parse(args); err != nil {
+		if errors.Is(err, flag.ErrHelp) {
+			return nil
+		}
+		return err
+	}
+
+	skills, errs := agentskill.Discover(s.FS)
+	for _, e := range errs {
+		fmt.Fprintf(errW, "warning: %v\n", e)
+	}
+
+	if len(skills) == 0 {
+		fmt.Fprintln(out, "no skills found")
+		return nil
+	}
+
+	for _, sk := range skills {
+		if sk.Description != "" {
+			fmt.Fprintf(out, "%-30s %s\n", sk.Dir, sk.Description)
+		} else {
+			fmt.Fprintln(out, sk.Dir)
+		}
+	}
+	return nil
+}

--- a/cmd_reinstall.go
+++ b/cmd_reinstall.go
@@ -1,0 +1,52 @@
+package skillsmith
+
+import (
+	"context"
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+)
+
+func (s *Smith) cmdReinstall(_ context.Context, args []string, out, errW io.Writer) error {
+	f := flag.NewFlagSet("reinstall", flag.ContinueOnError)
+	f.SetOutput(errW)
+	var cf commonFlags
+	addCommonFlags(f, &cf)
+	if err := f.Parse(args); err != nil {
+		if errors.Is(err, flag.ErrHelp) {
+			return nil
+		}
+		return err
+	}
+
+	dir, err := s.installDir(cf)
+	if err != nil {
+		return err
+	}
+
+	result, err := CopySkills(s.FS, dir, CopyOptions{
+		Mode:    ModeReinstall,
+		Force:   cf.force,
+		DryRun:  cf.dryRun,
+		Name:    s.Name,
+		Version: s.Version,
+	})
+	if err != nil {
+		return err
+	}
+
+	for _, a := range result.Actions {
+		switch a.Action {
+		case "reinstalled":
+			fmt.Fprintf(out, "reinstalled: %s\n", a.Dir)
+		case "warned":
+			fmt.Fprintf(errW, "warning:     %s — %s\n", a.Dir, a.Message)
+		}
+	}
+
+	if cf.dryRun {
+		fmt.Fprintln(out, "[dry-run] no changes were made")
+	}
+	return nil
+}

--- a/cmd_reinstall.go
+++ b/cmd_reinstall.go
@@ -39,7 +39,11 @@ func (s *Smith) cmdReinstall(_ context.Context, args []string, out, errW io.Writ
 	for _, a := range result.Actions {
 		switch a.Action {
 		case "reinstalled":
-			fmt.Fprintf(out, "reinstalled: %s\n", a.Dir)
+			if cf.dryRun {
+				fmt.Fprintln(out, a.Message)
+			} else {
+				fmt.Fprintf(out, "reinstalled: %s\n", a.Dir)
+			}
 		case "warned":
 			fmt.Fprintf(errW, "warning:     %s — %s\n", a.Dir, a.Message)
 		}

--- a/cmd_reinstall.go
+++ b/cmd_reinstall.go
@@ -40,7 +40,7 @@ func (s *Smith) cmdReinstall(_ context.Context, args []string, out, errW io.Writ
 		switch a.Action {
 		case "reinstalled":
 			if cf.dryRun {
-				fmt.Fprintln(out, a.Message)
+				fmt.Fprintf(out, "reinstalled (dry-run): %s\n", a.Dir)
 			} else {
 				fmt.Fprintf(out, "reinstalled: %s\n", a.Dir)
 			}

--- a/cmd_status.go
+++ b/cmd_status.go
@@ -1,0 +1,56 @@
+package skillsmith
+
+import (
+	"context"
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"path/filepath"
+
+	"github.com/Songmu/skillsmith/agentskill"
+)
+
+func (s *Smith) cmdStatus(_ context.Context, args []string, out, errW io.Writer) error {
+	f := flag.NewFlagSet("status", flag.ContinueOnError)
+	f.SetOutput(errW)
+	var cf commonFlags
+	addCommonFlags(f, &cf)
+	if err := f.Parse(args); err != nil {
+		if errors.Is(err, flag.ErrHelp) {
+			return nil
+		}
+		return err
+	}
+
+	dir, err := s.installDir(cf)
+	if err != nil {
+		return err
+	}
+
+	skills, errs := agentskill.Discover(s.FS)
+	for _, e := range errs {
+		fmt.Fprintf(errW, "warning: %v\n", e)
+	}
+
+	for _, skill := range skills {
+		dest := filepath.Join(dir, skill.Dir)
+		if !IsManaged(dest) {
+			fmt.Fprintf(out, "%-30s not installed\n", skill.Dir)
+			continue
+		}
+
+		meta, err := ReadMeta(dest)
+		if err != nil {
+			fmt.Fprintf(out, "%-30s installed (metadata unreadable: %v)\n", skill.Dir, err)
+			continue
+		}
+
+		if meta.Version == s.Version {
+			fmt.Fprintf(out, "%-30s installed %s (up to date)\n", skill.Dir, meta.Version)
+		} else {
+			fmt.Fprintf(out, "%-30s installed %s → available %s\n", skill.Dir, meta.Version, s.Version)
+		}
+	}
+	return nil
+}

--- a/cmd_status.go
+++ b/cmd_status.go
@@ -28,10 +28,10 @@ func (s *Smith) cmdStatus(_ context.Context, args []string, out, errW io.Writer)
 		return err
 	}
 
-	skills, errs := agentskill.Discover(s.FS)
-	for _, e := range errs {
+	skills, discoverErr := agentskill.Discover(s.FS)
+	eachError(discoverErr, func(e error) {
 		fmt.Fprintf(errW, "warning: %v\n", e)
-	}
+	})
 
 	for _, skill := range skills {
 		dest := filepath.Join(dir, skill.Dir)

--- a/cmd_status.go
+++ b/cmd_status.go
@@ -29,9 +29,20 @@ func (s *Smith) cmdStatus(_ context.Context, args []string, out, errW io.Writer)
 	}
 
 	skills, discoverErr := agentskill.Discover(s.FS)
+	var fatalErr error
 	eachError(discoverErr, func(e error) {
-		fmt.Fprintf(errW, "warning: %v\n", e)
+		var se *agentskill.SkillError
+		if errors.As(e, &se) {
+			fmt.Fprintf(errW, "warning: %v\n", e)
+			return
+		}
+		if fatalErr == nil {
+			fatalErr = e
+		}
 	})
+	if fatalErr != nil {
+		return fatalErr
+	}
 
 	for _, skill := range skills {
 		dest := filepath.Join(dir, skill.Dir)

--- a/cmd_uninstall.go
+++ b/cmd_uninstall.go
@@ -48,7 +48,7 @@ func (s *Smith) cmdUninstall(_ context.Context, args []string, out, errW io.Writ
 		}
 
 		if cf.dryRun {
-			fmt.Fprintf(out, "[dry-run] would uninstall: %s\n", skill.Dir)
+			fmt.Fprintf(out, "uninstalled (dry-run): %s\n", skill.Dir)
 			continue
 		}
 

--- a/cmd_uninstall.go
+++ b/cmd_uninstall.go
@@ -1,0 +1,59 @@
+package skillsmith
+
+import (
+	"context"
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+
+	"github.com/Songmu/skillsmith/agentskill"
+)
+
+func (s *Smith) cmdUninstall(_ context.Context, args []string, out, errW io.Writer) error {
+	f := flag.NewFlagSet("uninstall", flag.ContinueOnError)
+	f.SetOutput(errW)
+	var cf commonFlags
+	addCommonFlags(f, &cf)
+	if err := f.Parse(args); err != nil {
+		if errors.Is(err, flag.ErrHelp) {
+			return nil
+		}
+		return err
+	}
+
+	dir, err := s.installDir(cf)
+	if err != nil {
+		return err
+	}
+
+	skills, errs := agentskill.Discover(s.FS)
+	for _, e := range errs {
+		fmt.Fprintf(errW, "warning: %v\n", e)
+	}
+
+	for _, skill := range skills {
+		dest := filepath.Join(dir, skill.Dir)
+		if !IsManaged(dest) {
+			fmt.Fprintf(out, "skipped:     %s — not managed by skillsmith\n", skill.Dir)
+			continue
+		}
+
+		if cf.dryRun {
+			fmt.Fprintf(out, "[dry-run] would uninstall: %s\n", skill.Dir)
+			continue
+		}
+
+		if err := os.RemoveAll(dest); err != nil {
+			return fmt.Errorf("uninstalling %q: %w", skill.Dir, err)
+		}
+		fmt.Fprintf(out, "uninstalled: %s\n", skill.Dir)
+	}
+
+	if cf.dryRun {
+		fmt.Fprintln(out, "[dry-run] no changes were made")
+	}
+	return nil
+}

--- a/cmd_uninstall.go
+++ b/cmd_uninstall.go
@@ -29,10 +29,10 @@ func (s *Smith) cmdUninstall(_ context.Context, args []string, out, errW io.Writ
 		return err
 	}
 
-	skills, errs := agentskill.Discover(s.FS)
-	for _, e := range errs {
+	skills, discoverErr := agentskill.Discover(s.FS)
+	eachError(discoverErr, func(e error) {
 		fmt.Fprintf(errW, "warning: %v\n", e)
-	}
+	})
 
 	for _, skill := range skills {
 		dest := filepath.Join(dir, skill.Dir)

--- a/cmd_uninstall.go
+++ b/cmd_uninstall.go
@@ -30,9 +30,15 @@ func (s *Smith) cmdUninstall(_ context.Context, args []string, out, errW io.Writ
 	}
 
 	skills, discoverErr := agentskill.Discover(s.FS)
-	eachError(discoverErr, func(e error) {
-		fmt.Fprintf(errW, "warning: %v\n", e)
-	})
+	if discoverErr != nil {
+		var skillErr *agentskill.SkillError
+		if !errors.As(discoverErr, &skillErr) {
+			return discoverErr
+		}
+		eachError(discoverErr, func(e error) {
+			fmt.Fprintf(errW, "warning: %v\n", e)
+		})
+	}
 
 	for _, skill := range skills {
 		dest := filepath.Join(dir, skill.Dir)

--- a/cmd_update.go
+++ b/cmd_update.go
@@ -39,7 +39,11 @@ func (s *Smith) cmdUpdate(_ context.Context, args []string, out, errW io.Writer)
 	for _, a := range result.Actions {
 		switch a.Action {
 		case "updated":
-			fmt.Fprintf(out, "updated:   %s\n", a.Dir)
+			if cf.dryRun {
+				fmt.Fprintln(out, a.Message)
+			} else {
+				fmt.Fprintf(out, "updated:   %s\n", a.Dir)
+			}
 		case "skipped":
 			fmt.Fprintf(out, "skipped:   %s — %s\n", a.Dir, a.Message)
 		case "warned":

--- a/cmd_update.go
+++ b/cmd_update.go
@@ -40,7 +40,7 @@ func (s *Smith) cmdUpdate(_ context.Context, args []string, out, errW io.Writer)
 		switch a.Action {
 		case "updated":
 			if cf.dryRun {
-				fmt.Fprintln(out, a.Message)
+				fmt.Fprintf(out, "updated (dry-run): %s\n", a.Dir)
 			} else {
 				fmt.Fprintf(out, "updated:   %s\n", a.Dir)
 			}

--- a/cmd_update.go
+++ b/cmd_update.go
@@ -1,0 +1,54 @@
+package skillsmith
+
+import (
+	"context"
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+)
+
+func (s *Smith) cmdUpdate(_ context.Context, args []string, out, errW io.Writer) error {
+	f := flag.NewFlagSet("update", flag.ContinueOnError)
+	f.SetOutput(errW)
+	var cf commonFlags
+	addCommonFlags(f, &cf)
+	if err := f.Parse(args); err != nil {
+		if errors.Is(err, flag.ErrHelp) {
+			return nil
+		}
+		return err
+	}
+
+	dir, err := s.installDir(cf)
+	if err != nil {
+		return err
+	}
+
+	result, err := CopySkills(s.FS, dir, CopyOptions{
+		Mode:    ModeUpdate,
+		Force:   cf.force,
+		DryRun:  cf.dryRun,
+		Name:    s.Name,
+		Version: s.Version,
+	})
+	if err != nil {
+		return err
+	}
+
+	for _, a := range result.Actions {
+		switch a.Action {
+		case "updated":
+			fmt.Fprintf(out, "updated:   %s\n", a.Dir)
+		case "skipped":
+			fmt.Fprintf(out, "skipped:   %s — %s\n", a.Dir, a.Message)
+		case "warned":
+			fmt.Fprintf(errW, "warning:   %s — %s\n", a.Dir, a.Message)
+		}
+	}
+
+	if cf.dryRun {
+		fmt.Fprintln(out, "[dry-run] no changes were made")
+	}
+	return nil
+}

--- a/copy.go
+++ b/copy.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 	"io/fs"
+	"math/rand"
 	"os"
 	"path/filepath"
 	"time"
@@ -197,14 +198,11 @@ func copySkill(src fs.FS, destDir string, skill *agentskill.Skill, opts CopyOpti
 
 	// When the destination already exists, back it up first so that a failed
 	// copy can be rolled back without leaving a partially-written skill behind.
-	backup := dest + ".bak"
+	// A random suffix avoids collisions with any leftover backup from a prior interrupted install.
+	backup := fmt.Sprintf("%s.%08x.bak", dest, rand.Uint32())
 	destExists := false
 	if _, statErr := os.Stat(dest); statErr == nil {
 		destExists = true
-		// Remove any leftover backup from a prior interrupted install.
-		if removeErr := os.RemoveAll(backup); removeErr != nil {
-			return "", "", fmt.Errorf("removing stale backup of %q: %w", skill.Dir, removeErr)
-		}
 		if renameErr := os.Rename(dest, backup); renameErr != nil {
 			return "", "", fmt.Errorf("creating backup of %q: %w", skill.Dir, renameErr)
 		}

--- a/copy.go
+++ b/copy.go
@@ -225,11 +225,19 @@ func copySkill(src fs.FS, destDir string, skill *agentskill.Skill, opts CopyOpti
 
 	if copyErr != nil {
 		// Clean up the destination and restore the backup (if any) if the copy or metadata write failed.
-		_ = os.RemoveAll(dest)
-		if destExists {
-			_ = os.Rename(backup, dest)
+		combinedErr := copyErr
+
+		if rmErr := os.RemoveAll(dest); rmErr != nil {
+			combinedErr = errors.Join(combinedErr, fmt.Errorf("removing destination %q during rollback: %w", dest, rmErr))
 		}
-		return "", "", copyErr
+
+		if destExists {
+			if restoreErr := os.Rename(backup, dest); restoreErr != nil {
+				combinedErr = errors.Join(combinedErr, fmt.Errorf("restoring backup from %q to %q during rollback: %w", backup, dest, restoreErr))
+			}
+		}
+
+		return "", "", combinedErr
 	}
 
 	// Success — remove the backup.

--- a/copy.go
+++ b/copy.go
@@ -11,7 +11,7 @@ import (
 	"github.com/Songmu/skillsmith/agentskill"
 )
 
-// CopyMode controls the install/update/reinstall behaviour.
+// CopyMode controls the install/update/reinstall behavior.
 type CopyMode int
 
 const (
@@ -23,7 +23,7 @@ const (
 	ModeReinstall
 )
 
-// CopyOptions configures the behaviour of CopySkills.
+// CopyOptions configures the behavior of CopySkills.
 type CopyOptions struct {
 	// Mode determines whether this is an install, update, or reinstall.
 	Mode CopyMode
@@ -44,7 +44,7 @@ type SkillAction struct {
 	Message string
 }
 
-// CopyResult summarises the outcome of a CopySkills call.
+// CopyResult summarizes the outcome of a CopySkills call.
 type CopyResult struct {
 	Actions []SkillAction
 }

--- a/copy.go
+++ b/copy.go
@@ -5,7 +5,8 @@ import (
 	"fmt"
 	"io"
 	"io/fs"
-	"math/rand"
+	crand "crypto/rand"
+	"encoding/hex"
 	"os"
 	"path/filepath"
 	"time"
@@ -199,7 +200,12 @@ func copySkill(src fs.FS, destDir string, skill *agentskill.Skill, opts CopyOpti
 	// When the destination already exists, back it up first so that a failed
 	// copy can be rolled back without leaving a partially-written skill behind.
 	// A random suffix avoids collisions with any leftover backup from a prior interrupted install.
-	backup := fmt.Sprintf("%s.%08x.bak", dest, rand.Uint32())
+	randBytes := make([]byte, 4)
+	if _, err := crand.Read(randBytes); err != nil {
+		return "", "", fmt.Errorf("generating backup suffix for %q: %w", skill.Dir, err)
+	}
+	backupSuffix := hex.EncodeToString(randBytes)
+	backup := fmt.Sprintf("%s.%s.bak", dest, backupSuffix)
 	destExists := false
 	if _, statErr := os.Stat(dest); statErr == nil {
 		destExists = true

--- a/copy.go
+++ b/copy.go
@@ -108,14 +108,23 @@ func CopySkills(src fs.FS, destDir string, opts CopyOptions) (*CopyResult, error
 	skills, discoverErr := agentskill.Discover(src)
 	result := &CopyResult{}
 
+	var fatalErr error
 	eachError(discoverErr, func(e error) {
 		var se *agentskill.SkillError
 		if errors.As(e, &se) {
 			result.add(se.Dir, "warned", se.Err.Error())
+			return
+		}
+		// Treat non-SkillError discovery failures as fatal.
+		if fatalErr == nil {
+			fatalErr = e
 		} else {
-			result.add("", "warned", e.Error())
+			fatalErr = errors.Join(fatalErr, e)
 		}
 	})
+	if fatalErr != nil {
+		return result, fmt.Errorf("discovering skills: %w", fatalErr)
+	}
 
 	for _, skill := range skills {
 		action, msg, err := copySkill(src, destDir, skill, opts)

--- a/copy.go
+++ b/copy.go
@@ -200,15 +200,16 @@ func copySkill(src fs.FS, destDir string, skill *agentskill.Skill, opts CopyOpti
 	// When the destination already exists, back it up first so that a failed
 	// copy can be rolled back without leaving a partially-written skill behind.
 	// A random suffix avoids collisions with any leftover backup from a prior interrupted install.
-	randBytes := make([]byte, 4)
-	if _, err := crand.Read(randBytes); err != nil {
-		return "", "", fmt.Errorf("generating backup suffix for %q: %w", skill.Dir, err)
-	}
-	backupSuffix := hex.EncodeToString(randBytes)
-	backup := fmt.Sprintf("%s.%s.bak", dest, backupSuffix)
 	destExists := false
+	var backup string
 	if _, statErr := os.Stat(dest); statErr == nil {
 		destExists = true
+		randBytes := make([]byte, 4)
+		if _, err := crand.Read(randBytes); err != nil {
+			return "", "", fmt.Errorf("generating backup suffix for %q: %w", skill.Dir, err)
+		}
+		backupSuffix := hex.EncodeToString(randBytes)
+		backup = fmt.Sprintf("%s.%s.bak", dest, backupSuffix)
 		if renameErr := os.Rename(dest, backup); renameErr != nil {
 			return "", "", fmt.Errorf("creating backup of %q: %w", skill.Dir, renameErr)
 		}

--- a/copy.go
+++ b/copy.go
@@ -151,7 +151,7 @@ func copySkill(src fs.FS, destDir string, skill *agentskill.Skill, opts CopyOpti
 
 	case ModeUpdate:
 		if !managed {
-			// Not managed — skip silently.
+			// Not managed — skip with a user-visible reason.
 			return "skipped", fmt.Sprintf("skill %q is not managed by skillsmith", skill.Dir), nil
 		}
 		meta, readErr := ReadMeta(dest)

--- a/copy.go
+++ b/copy.go
@@ -222,9 +222,9 @@ func copySkill(src fs.FS, destDir string, skill *agentskill.Skill, opts CopyOpti
 	}
 
 	if copyErr != nil {
-		// Restore the backup if the copy or metadata write failed.
+		// Clean up the destination and restore the backup (if any) if the copy or metadata write failed.
+		_ = os.RemoveAll(dest)
 		if destExists {
-			_ = os.RemoveAll(dest)
 			_ = os.Rename(backup, dest)
 		}
 		return "", "", copyErr

--- a/copy.go
+++ b/copy.go
@@ -201,6 +201,10 @@ func copySkill(src fs.FS, destDir string, skill *agentskill.Skill, opts CopyOpti
 	destExists := false
 	if _, statErr := os.Stat(dest); statErr == nil {
 		destExists = true
+		// Remove any leftover backup from a prior interrupted install.
+		if removeErr := os.RemoveAll(backup); removeErr != nil {
+			return "", "", fmt.Errorf("removing stale backup of %q: %w", skill.Dir, removeErr)
+		}
 		if renameErr := os.Rename(dest, backup); renameErr != nil {
 			return "", "", fmt.Errorf("creating backup of %q: %w", skill.Dir, renameErr)
 		}

--- a/copy.go
+++ b/copy.go
@@ -1,6 +1,7 @@
 package skillsmith
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"io/fs"
@@ -82,15 +83,39 @@ func (r *CopyResult) add(dir, action, msg string) {
 	r.Actions = append(r.Actions, SkillAction{Dir: dir, Action: action, Message: msg})
 }
 
+// eachError calls fn for each individual error in err. If err wraps multiple
+// errors (e.g. from [errors.Join]), fn is called for each element. If err is
+// nil, fn is never called.
+func eachError(err error, fn func(error)) {
+	if err == nil {
+		return
+	}
+	type multiErr interface {
+		Unwrap() []error
+	}
+	if me, ok := err.(multiErr); ok {
+		for _, e := range me.Unwrap() {
+			fn(e)
+		}
+		return
+	}
+	fn(err)
+}
+
 // CopySkills copies skills from src (an fs.FS whose top-level directories are
 // skill directories) into destDir.
 func CopySkills(src fs.FS, destDir string, opts CopyOptions) (*CopyResult, error) {
-	skills, errs := agentskill.Discover(src)
+	skills, discoverErr := agentskill.Discover(src)
 	result := &CopyResult{}
 
-	for _, err := range errs {
-		result.add("", "warned", err.Error())
-	}
+	eachError(discoverErr, func(e error) {
+		var se *agentskill.SkillError
+		if errors.As(e, &se) {
+			result.add(se.Dir, "warned", se.Err.Error())
+		} else {
+			result.add("", "warned", e.Error())
+		}
+	})
 
 	for _, skill := range skills {
 		action, msg, err := copySkill(src, destDir, skill, opts)
@@ -105,7 +130,7 @@ func CopySkills(src fs.FS, destDir string, opts CopyOptions) (*CopyResult, error
 
 // copySkill handles the copy logic for a single skill directory.
 // It returns the action taken ("installed", "updated", "reinstalled", "skipped", "warned").
-func copySkill(src fs.FS, destDir string, skill agentskill.Skill, opts CopyOptions) (action, msg string, err error) {
+func copySkill(src fs.FS, destDir string, skill *agentskill.Skill, opts CopyOptions) (action, msg string, err error) {
 	dest := filepath.Join(destDir, skill.Dir)
 	managed := IsManaged(dest)
 

--- a/copy.go
+++ b/copy.go
@@ -1,0 +1,225 @@
+package skillsmith
+
+import (
+	"fmt"
+	"io"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/Songmu/skillsmith/agentskill"
+)
+
+// CopyMode controls the install/update/reinstall behaviour.
+type CopyMode int
+
+const (
+	// ModeInstall installs new skills; skips existing managed skills.
+	ModeInstall CopyMode = iota
+	// ModeUpdate re-installs managed skills whose version has changed.
+	ModeUpdate
+	// ModeReinstall overwrites all managed skills regardless of version.
+	ModeReinstall
+)
+
+// CopyOptions configures the behaviour of CopySkills.
+type CopyOptions struct {
+	// Mode determines whether this is an install, update, or reinstall.
+	Mode CopyMode
+	// Force allows overwriting unmanaged (externally placed) skills.
+	Force bool
+	// DryRun reports what would happen without making any changes.
+	DryRun bool
+	// Name is the tool name written to .skillsmith.json (installedBy).
+	Name string
+	// Version is the tool version written to .skillsmith.json.
+	Version string
+}
+
+// SkillAction describes what happened to a single skill during CopySkills.
+type SkillAction struct {
+	Dir     string
+	Action  string // "installed", "updated", "reinstalled", "skipped", "warned"
+	Message string
+}
+
+// CopyResult summarises the outcome of a CopySkills call.
+type CopyResult struct {
+	Actions []SkillAction
+}
+
+// Installed returns the actions whose Action is "installed", "updated", or "reinstalled".
+func (r *CopyResult) Installed() []SkillAction {
+	return r.filter("installed", "updated", "reinstalled")
+}
+
+// Skipped returns the actions whose Action is "skipped".
+func (r *CopyResult) Skipped() []SkillAction {
+	return r.filter("skipped")
+}
+
+// Warned returns the actions whose Action is "warned".
+func (r *CopyResult) Warned() []SkillAction {
+	return r.filter("warned")
+}
+
+func (r *CopyResult) filter(actions ...string) []SkillAction {
+	set := make(map[string]bool, len(actions))
+	for _, a := range actions {
+		set[a] = true
+	}
+	var out []SkillAction
+	for _, a := range r.Actions {
+		if set[a.Action] {
+			out = append(out, a)
+		}
+	}
+	return out
+}
+
+func (r *CopyResult) add(dir, action, msg string) {
+	r.Actions = append(r.Actions, SkillAction{Dir: dir, Action: action, Message: msg})
+}
+
+// CopySkills copies skills from src (an fs.FS whose top-level directories are
+// skill directories) into destDir.
+func CopySkills(src fs.FS, destDir string, opts CopyOptions) (*CopyResult, error) {
+	skills, errs := agentskill.Discover(src)
+	result := &CopyResult{}
+
+	for _, err := range errs {
+		result.add("", "warned", err.Error())
+	}
+
+	for _, skill := range skills {
+		action, msg, err := copySkill(src, destDir, skill, opts)
+		if err != nil {
+			return result, fmt.Errorf("copying skill %q: %w", skill.Dir, err)
+		}
+		result.add(skill.Dir, action, msg)
+	}
+
+	return result, nil
+}
+
+// copySkill handles the copy logic for a single skill directory.
+// It returns the action taken ("installed", "updated", "reinstalled", "skipped", "warned").
+func copySkill(src fs.FS, destDir string, skill agentskill.Skill, opts CopyOptions) (action, msg string, err error) {
+	dest := filepath.Join(destDir, skill.Dir)
+	managed := IsManaged(dest)
+
+	switch opts.Mode {
+	case ModeInstall:
+		if _, statErr := os.Stat(dest); statErr == nil {
+			// Destination exists.
+			if !managed {
+				if !opts.Force {
+					return "warned", fmt.Sprintf("skill %q exists but is not managed by skillsmith; use --force to overwrite", skill.Dir), nil
+				}
+				// Force overwrite of unmanaged skill.
+			} else {
+				// Managed and exists — skip on install.
+				return "skipped", fmt.Sprintf("skill %q already installed (use 'update' or 'reinstall' to refresh)", skill.Dir), nil
+			}
+		}
+
+	case ModeUpdate:
+		if !managed {
+			// Not managed — skip silently.
+			return "skipped", fmt.Sprintf("skill %q is not managed by skillsmith", skill.Dir), nil
+		}
+		meta, readErr := ReadMeta(dest)
+		if readErr == nil && meta.Version == opts.Version {
+			// Same version — nothing to do.
+			return "skipped", fmt.Sprintf("skill %q is already at version %q", skill.Dir, opts.Version), nil
+		}
+
+	case ModeReinstall:
+		if !managed {
+			if !opts.Force {
+				return "warned", fmt.Sprintf("skill %q is not managed by skillsmith; use --force to overwrite", skill.Dir), nil
+			}
+		}
+	}
+
+	if opts.DryRun {
+		label := "installed"
+		if managed {
+			label = map[CopyMode]string{
+				ModeUpdate:    "updated",
+				ModeReinstall: "reinstalled",
+			}[opts.Mode]
+			if label == "" {
+				label = "installed"
+			}
+		}
+		return label, fmt.Sprintf("[dry-run] would %s skill %q", label, skill.Dir), nil
+	}
+
+	// Perform the actual file copy.
+	if err := copyFSDir(src, skill.Dir, dest); err != nil {
+		return "", "", err
+	}
+
+	// Write metadata.
+	meta := &SkillMeta{
+		InstalledBy: opts.Name,
+		Version:     opts.Version,
+		InstalledAt: time.Now().UTC(),
+	}
+	if err := WriteMeta(dest, meta); err != nil {
+		return "", "", fmt.Errorf("writing metadata for %q: %w", skill.Dir, err)
+	}
+
+	label := "installed"
+	if opts.Mode == ModeUpdate {
+		label = "updated"
+	} else if opts.Mode == ModeReinstall {
+		label = "reinstalled"
+	}
+	return label, "", nil
+}
+
+// copyFSDir copies the directory srcDir from fsys into destDir on disk,
+// preserving the directory structure.
+func copyFSDir(fsys fs.FS, srcDir, destDir string) error {
+	return fs.WalkDir(fsys, srcDir, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		rel, relErr := filepath.Rel(srcDir, path)
+		if relErr != nil {
+			return relErr
+		}
+		dest := filepath.Join(destDir, rel)
+
+		if d.IsDir() {
+			return os.MkdirAll(dest, 0o755)
+		}
+
+		return copyFile(fsys, path, dest)
+	})
+}
+
+// copyFile copies a single file from fsys to destPath.
+func copyFile(fsys fs.FS, srcPath, destPath string) error {
+	src, err := fsys.Open(srcPath)
+	if err != nil {
+		return err
+	}
+	defer src.Close() //nolint:errcheck
+
+	if err := os.MkdirAll(filepath.Dir(destPath), 0o755); err != nil {
+		return err
+	}
+
+	dst, err := os.Create(destPath)
+	if err != nil {
+		return err
+	}
+	defer dst.Close() //nolint:errcheck
+
+	_, err = io.Copy(dst, src)
+	return err
+}

--- a/copy.go
+++ b/copy.go
@@ -187,27 +187,54 @@ func copySkill(src fs.FS, destDir string, skill *agentskill.Skill, opts CopyOpti
 		return label, fmt.Sprintf("[dry-run] would %s skill %q", label, skill.Dir), nil
 	}
 
-	// Perform the actual file copy.
-	if err := copyFSDir(src, skill.Dir, dest); err != nil {
-		return "", "", err
-	}
-
-	// Write metadata.
-	meta := &SkillMeta{
-		InstalledBy: opts.Name,
-		Version:     opts.Version,
-		InstalledAt: time.Now().UTC(),
-	}
-	if err := WriteMeta(dest, meta); err != nil {
-		return "", "", fmt.Errorf("writing metadata for %q: %w", skill.Dir, err)
-	}
-
+	// Determine the label for the action.
 	label := "installed"
 	if opts.Mode == ModeUpdate {
 		label = "updated"
 	} else if opts.Mode == ModeReinstall {
 		label = "reinstalled"
 	}
+
+	// When the destination already exists, back it up first so that a failed
+	// copy can be rolled back without leaving a partially-written skill behind.
+	backup := dest + ".bak"
+	destExists := false
+	if _, statErr := os.Stat(dest); statErr == nil {
+		destExists = true
+		if renameErr := os.Rename(dest, backup); renameErr != nil {
+			return "", "", fmt.Errorf("creating backup of %q: %w", skill.Dir, renameErr)
+		}
+	}
+
+	// Perform the actual file copy.
+	copyErr := copyFSDir(src, skill.Dir, dest)
+	if copyErr == nil {
+		// Write metadata.
+		meta := &SkillMeta{
+			InstalledBy: opts.Name,
+			Version:     opts.Version,
+			InstalledAt: time.Now().UTC(),
+		}
+		copyErr = WriteMeta(dest, meta)
+		if copyErr != nil {
+			copyErr = fmt.Errorf("writing metadata for %q: %w", skill.Dir, copyErr)
+		}
+	}
+
+	if copyErr != nil {
+		// Restore the backup if the copy or metadata write failed.
+		if destExists {
+			_ = os.RemoveAll(dest)
+			_ = os.Rename(backup, dest)
+		}
+		return "", "", copyErr
+	}
+
+	// Success — remove the backup.
+	if destExists {
+		_ = os.RemoveAll(backup)
+	}
+
 	return label, "", nil
 }
 

--- a/copy.go
+++ b/copy.go
@@ -179,14 +179,10 @@ func copySkill(src fs.FS, destDir string, skill *agentskill.Skill, opts CopyOpti
 
 	if opts.DryRun {
 		label := "installed"
-		if managed {
-			label = map[CopyMode]string{
-				ModeUpdate:    "updated",
-				ModeReinstall: "reinstalled",
-			}[opts.Mode]
-			if label == "" {
-				label = "installed"
-			}
+		if opts.Mode == ModeUpdate {
+			label = "updated"
+		} else if opts.Mode == ModeReinstall {
+			label = "reinstalled"
 		}
 		return label, fmt.Sprintf("[dry-run] would %s skill %q", label, skill.Dir), nil
 	}

--- a/copy_test.go
+++ b/copy_test.go
@@ -1,0 +1,222 @@
+package skillsmith
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"testing/fstest"
+)
+
+func newTestFS() fstest.MapFS {
+	return fstest.MapFS{
+		"mytool/SKILL.md": {
+			Data: []byte(`---
+name: mytool
+description: A test skill
+---
+body
+`),
+		},
+		"mytool/README.md": {
+			Data: []byte("# mytool\n"),
+		},
+	}
+}
+
+func TestCopySkills_Install(t *testing.T) {
+	src := newTestFS()
+	dest := t.TempDir()
+
+	result, err := CopySkills(src, dest, CopyOptions{
+		Mode:    ModeInstall,
+		Name:    "tool",
+		Version: "v1.0.0",
+	})
+	if err != nil {
+		t.Fatalf("CopySkills: %v", err)
+	}
+
+	installed := result.Installed()
+	if len(installed) != 1 || installed[0].Dir != "mytool" {
+		t.Errorf("expected 1 installed skill, got: %v", installed)
+	}
+
+	// SKILL.md should be on disk.
+	if _, err := os.Stat(filepath.Join(dest, "mytool", "SKILL.md")); err != nil {
+		t.Errorf("SKILL.md not found after install: %v", err)
+	}
+
+	// .skillsmith.json should be on disk.
+	if !IsManaged(filepath.Join(dest, "mytool")) {
+		t.Error(".skillsmith.json not found after install")
+	}
+
+	meta, err := ReadMeta(filepath.Join(dest, "mytool"))
+	if err != nil {
+		t.Fatalf("ReadMeta: %v", err)
+	}
+	if meta.InstalledBy != "tool" {
+		t.Errorf("InstalledBy = %q, want %q", meta.InstalledBy, "tool")
+	}
+	if meta.Version != "v1.0.0" {
+		t.Errorf("Version = %q, want %q", meta.Version, "v1.0.0")
+	}
+}
+
+func TestCopySkills_Install_SkipsExisting(t *testing.T) {
+	src := newTestFS()
+	dest := t.TempDir()
+
+	// First install.
+	if _, err := CopySkills(src, dest, CopyOptions{Mode: ModeInstall, Name: "tool", Version: "v1"}); err != nil {
+		t.Fatalf("first install: %v", err)
+	}
+
+	// Second install should skip.
+	result, err := CopySkills(src, dest, CopyOptions{Mode: ModeInstall, Name: "tool", Version: "v2"})
+	if err != nil {
+		t.Fatalf("second install: %v", err)
+	}
+
+	if len(result.Skipped()) != 1 {
+		t.Errorf("expected 1 skipped skill on second install, got: %v", result.Skipped())
+	}
+
+	// Version should still be v1 (not overwritten).
+	meta, _ := ReadMeta(filepath.Join(dest, "mytool"))
+	if meta.Version != "v1" {
+		t.Errorf("expected version to remain v1, got %q", meta.Version)
+	}
+}
+
+func TestCopySkills_Install_WarnsUnmanaged(t *testing.T) {
+	src := newTestFS()
+	dest := t.TempDir()
+
+	// Create an unmanaged skill directory (no .skillsmith.json).
+	if err := os.MkdirAll(filepath.Join(dest, "mytool"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	result, err := CopySkills(src, dest, CopyOptions{Mode: ModeInstall, Name: "tool", Version: "v1"})
+	if err != nil {
+		t.Fatalf("CopySkills: %v", err)
+	}
+
+	if len(result.Warned()) != 1 {
+		t.Errorf("expected 1 warned skill for unmanaged, got: %v", result.Warned())
+	}
+}
+
+func TestCopySkills_Install_ForceUnmanaged(t *testing.T) {
+	src := newTestFS()
+	dest := t.TempDir()
+
+	if err := os.MkdirAll(filepath.Join(dest, "mytool"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	result, err := CopySkills(src, dest, CopyOptions{Mode: ModeInstall, Name: "tool", Version: "v1", Force: true})
+	if err != nil {
+		t.Fatalf("CopySkills: %v", err)
+	}
+
+	if len(result.Installed()) != 1 {
+		t.Errorf("expected 1 installed skill with --force, got: %v", result.Installed())
+	}
+}
+
+func TestCopySkills_Update_SameVersion(t *testing.T) {
+	src := newTestFS()
+	dest := t.TempDir()
+
+	if _, err := CopySkills(src, dest, CopyOptions{Mode: ModeInstall, Name: "tool", Version: "v1"}); err != nil {
+		t.Fatalf("install: %v", err)
+	}
+
+	result, err := CopySkills(src, dest, CopyOptions{Mode: ModeUpdate, Name: "tool", Version: "v1"})
+	if err != nil {
+		t.Fatalf("update: %v", err)
+	}
+
+	if len(result.Skipped()) != 1 {
+		t.Errorf("expected 1 skipped skill (same version), got: %v", result.Skipped())
+	}
+}
+
+func TestCopySkills_Update_DifferentVersion(t *testing.T) {
+	src := newTestFS()
+	dest := t.TempDir()
+
+	if _, err := CopySkills(src, dest, CopyOptions{Mode: ModeInstall, Name: "tool", Version: "v1"}); err != nil {
+		t.Fatalf("install: %v", err)
+	}
+
+	result, err := CopySkills(src, dest, CopyOptions{Mode: ModeUpdate, Name: "tool", Version: "v2"})
+	if err != nil {
+		t.Fatalf("update: %v", err)
+	}
+
+	if len(result.Installed()) != 1 || result.Installed()[0].Action != "updated" {
+		t.Errorf("expected 1 updated skill, got: %v", result.Installed())
+	}
+
+	meta, _ := ReadMeta(filepath.Join(dest, "mytool"))
+	if meta.Version != "v2" {
+		t.Errorf("expected version v2 after update, got %q", meta.Version)
+	}
+}
+
+func TestCopySkills_Reinstall(t *testing.T) {
+	src := newTestFS()
+	dest := t.TempDir()
+
+	if _, err := CopySkills(src, dest, CopyOptions{Mode: ModeInstall, Name: "tool", Version: "v1"}); err != nil {
+		t.Fatalf("install: %v", err)
+	}
+
+	result, err := CopySkills(src, dest, CopyOptions{Mode: ModeReinstall, Name: "tool", Version: "v1"})
+	if err != nil {
+		t.Fatalf("reinstall: %v", err)
+	}
+
+	if len(result.Installed()) != 1 || result.Installed()[0].Action != "reinstalled" {
+		t.Errorf("expected 1 reinstalled skill, got: %v", result.Installed())
+	}
+}
+
+func TestCopySkills_DryRun(t *testing.T) {
+	src := newTestFS()
+	dest := t.TempDir()
+
+	result, err := CopySkills(src, dest, CopyOptions{Mode: ModeInstall, Name: "tool", Version: "v1", DryRun: true})
+	if err != nil {
+		t.Fatalf("CopySkills dry-run: %v", err)
+	}
+
+	if len(result.Installed()) != 1 {
+		t.Errorf("expected 1 dry-run installed skill, got: %v", result.Installed())
+	}
+
+	// Nothing should have been written to disk.
+	if _, err := os.Stat(filepath.Join(dest, "mytool")); err == nil {
+		t.Error("expected no files written in dry-run mode, but directory exists")
+	}
+}
+
+func TestCopySkills_InvalidSKILLmd(t *testing.T) {
+	src := fstest.MapFS{
+		"bad-skill/SKILL.md": {Data: []byte("no frontmatter")},
+	}
+	dest := t.TempDir()
+
+	result, err := CopySkills(src, dest, CopyOptions{Mode: ModeInstall})
+	if err != nil {
+		t.Fatalf("CopySkills: %v", err)
+	}
+
+	// The bad skill should produce a warning.
+	if len(result.Warned()) == 0 {
+		t.Error("expected at least one warning for bad SKILL.md, got none")
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,5 @@
 module github.com/Songmu/skillsmith
 
 go 1.26.1
+
+require github.com/goccy/go-yaml v1.19.2

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,2 @@
+github.com/goccy/go-yaml v1.19.2 h1:PmFC1S6h8ljIz6gMRBopkjP1TVT7xuwrButHID66PoM=
+github.com/goccy/go-yaml v1.19.2/go.mod h1:XBurs7gK8ATbW4ZPGKgcbrY1Br56PdM69F7LkFRi1kA=

--- a/metadata.go
+++ b/metadata.go
@@ -2,7 +2,6 @@ package skillsmith
 
 import (
 	"encoding/json"
-	"errors"
 	"os"
 	"path/filepath"
 	"time"

--- a/metadata.go
+++ b/metadata.go
@@ -1,0 +1,47 @@
+package skillsmith
+
+import (
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+	"time"
+)
+
+const metaFilename = ".skillsmith.json"
+
+// SkillMeta holds metadata written alongside an installed skill.
+type SkillMeta struct {
+	InstalledBy string    `json:"installedBy"`
+	Version     string    `json:"version"`
+	InstalledAt time.Time `json:"installedAt"`
+}
+
+// ReadMeta reads .skillsmith.json from the given skill directory.
+// It returns an error when the file cannot be read or decoded.
+func ReadMeta(dir string) (*SkillMeta, error) {
+	data, err := os.ReadFile(filepath.Join(dir, metaFilename))
+	if err != nil {
+		return nil, err
+	}
+	var m SkillMeta
+	if err := json.Unmarshal(data, &m); err != nil {
+		return nil, err
+	}
+	return &m, nil
+}
+
+// WriteMeta writes meta as .skillsmith.json into dir.
+func WriteMeta(dir string, meta *SkillMeta) error {
+	data, err := json.Marshal(meta)
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(filepath.Join(dir, metaFilename), data, 0o644)
+}
+
+// IsManaged reports whether a .skillsmith.json file exists in dir.
+func IsManaged(dir string) bool {
+	_, err := os.Stat(filepath.Join(dir, metaFilename))
+	return !errors.Is(err, os.ErrNotExist)
+}

--- a/metadata.go
+++ b/metadata.go
@@ -43,5 +43,5 @@ func WriteMeta(dir string, meta *SkillMeta) error {
 // IsManaged reports whether a .skillsmith.json file exists in dir.
 func IsManaged(dir string) bool {
 	_, err := os.Stat(filepath.Join(dir, metaFilename))
-	return !errors.Is(err, os.ErrNotExist)
+	return err == nil
 }

--- a/metadata_test.go
+++ b/metadata_test.go
@@ -1,0 +1,94 @@
+package skillsmith
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestWriteReadMeta(t *testing.T) {
+	dir := t.TempDir()
+
+	meta := &SkillMeta{
+		InstalledBy: "mytool",
+		Version:     "v1.2.3",
+		InstalledAt: time.Date(2026, 3, 13, 16, 30, 0, 0, time.UTC),
+	}
+
+	if err := WriteMeta(dir, meta); err != nil {
+		t.Fatalf("WriteMeta: %v", err)
+	}
+
+	got, err := ReadMeta(dir)
+	if err != nil {
+		t.Fatalf("ReadMeta: %v", err)
+	}
+
+	if got.InstalledBy != meta.InstalledBy {
+		t.Errorf("InstalledBy = %q, want %q", got.InstalledBy, meta.InstalledBy)
+	}
+	if got.Version != meta.Version {
+		t.Errorf("Version = %q, want %q", got.Version, meta.Version)
+	}
+	if !got.InstalledAt.Equal(meta.InstalledAt) {
+		t.Errorf("InstalledAt = %v, want %v", got.InstalledAt, meta.InstalledAt)
+	}
+}
+
+func TestWriteMeta_JSONFormat(t *testing.T) {
+	dir := t.TempDir()
+
+	meta := &SkillMeta{
+		InstalledBy: "tool",
+		Version:     "v0.1.0",
+		InstalledAt: time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC),
+	}
+
+	if err := WriteMeta(dir, meta); err != nil {
+		t.Fatalf("WriteMeta: %v", err)
+	}
+
+	data, err := os.ReadFile(filepath.Join(dir, ".skillsmith.json"))
+	if err != nil {
+		t.Fatalf("reading file: %v", err)
+	}
+
+	var raw map[string]any
+	if err := json.Unmarshal(data, &raw); err != nil {
+		t.Fatalf("json.Unmarshal: %v", err)
+	}
+
+	// Verify camelCase keys.
+	for _, key := range []string{"installedBy", "version", "installedAt"} {
+		if _, ok := raw[key]; !ok {
+			t.Errorf("JSON key %q not found in output", key)
+		}
+	}
+}
+
+func TestIsManaged(t *testing.T) {
+	dir := t.TempDir()
+
+	if IsManaged(dir) {
+		t.Error("expected IsManaged=false for empty directory, got true")
+	}
+
+	meta := &SkillMeta{InstalledBy: "tool", Version: "v1", InstalledAt: time.Now()}
+	if err := WriteMeta(dir, meta); err != nil {
+		t.Fatalf("WriteMeta: %v", err)
+	}
+
+	if !IsManaged(dir) {
+		t.Error("expected IsManaged=true after WriteMeta, got false")
+	}
+}
+
+func TestReadMeta_Missing(t *testing.T) {
+	dir := t.TempDir()
+	_, err := ReadMeta(dir)
+	if err == nil {
+		t.Error("expected error reading missing meta, got nil")
+	}
+}

--- a/resolve.go
+++ b/resolve.go
@@ -7,10 +7,21 @@ import (
 	"strings"
 )
 
-// DefaultInstallDir returns the default skill installation directory
-// (~/.agents/skills), which is the cross-client standard for agent skills.
-func DefaultInstallDir() (string, error) {
-	return expandHome("~/.agents/skills")
+// InstallDirForScope returns the skill installation directory for the given
+// scope. An empty scope defaults to "user".
+//
+//   - user (default): ~/.agents/skills  (absolute, under the user's home directory)
+//   - repo:           .agents/skills    (relative to the current working directory;
+//     the caller should ensure it is invoked from the repository root)
+func InstallDirForScope(scope string) (string, error) {
+	switch scope {
+	case "", "user":
+		return expandHome("~/.agents/skills")
+	case "repo":
+		return filepath.FromSlash(".agents/skills"), nil
+	default:
+		return "", fmt.Errorf("unknown scope %q (supported: user, repo)", scope)
+	}
 }
 
 // expandHome replaces a leading "~" with the user's home directory and

--- a/resolve.go
+++ b/resolve.go
@@ -1,0 +1,61 @@
+package skillsmith
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// agentScopePaths maps (agent, scope) to installation path patterns.
+// A leading "~" is expanded to the user's home directory.
+var agentScopePaths = map[string]map[string]string{
+	"codex": {
+		"user": "~/.codex/skills",
+		"repo": ".agents/skills",
+	},
+	"claude": {
+		"user": "~/.claude/skills",
+		"repo": ".claude/skills",
+	},
+	"agents": {
+		"user": "~/.agents/skills",
+		"repo": ".agents/skills",
+	},
+}
+
+// ResolveInstallDir returns the skill installation directory for the given
+// agent and scope. An empty agent defaults to "claude"; an empty scope
+// defaults to "user".
+func ResolveInstallDir(agent, scope string) (string, error) {
+	if agent == "" {
+		agent = "claude"
+	}
+	if scope == "" {
+		scope = "user"
+	}
+
+	scopes, ok := agentScopePaths[agent]
+	if !ok {
+		return "", fmt.Errorf("unknown agent %q (supported: codex, claude, agents)", agent)
+	}
+
+	p, ok := scopes[scope]
+	if !ok {
+		return "", fmt.Errorf("unknown scope %q for agent %q (supported: user, repo)", scope, agent)
+	}
+
+	return expandHome(p)
+}
+
+// expandHome replaces a leading "~" with the user's home directory.
+func expandHome(p string) (string, error) {
+	if !strings.HasPrefix(p, "~") {
+		return p, nil
+	}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", fmt.Errorf("resolving home directory: %w", err)
+	}
+	return filepath.Join(home, p[1:]), nil
+}

--- a/resolve.go
+++ b/resolve.go
@@ -48,10 +48,11 @@ func ResolveInstallDir(agent, scope string) (string, error) {
 	return expandHome(p)
 }
 
-// expandHome replaces a leading "~" with the user's home directory.
+// expandHome replaces a leading "~" with the user's home directory and
+// normalizes path separators for the current OS.
 func expandHome(p string) (string, error) {
 	if !strings.HasPrefix(p, "~") {
-		return p, nil
+		return filepath.FromSlash(p), nil
 	}
 	home, err := os.UserHomeDir()
 	if err != nil {

--- a/resolve.go
+++ b/resolve.go
@@ -7,45 +7,10 @@ import (
 	"strings"
 )
 
-// agentScopePaths maps (agent, scope) to installation path patterns.
-// A leading "~" is expanded to the user's home directory.
-var agentScopePaths = map[string]map[string]string{
-	"codex": {
-		"user": "~/.codex/skills",
-		"repo": ".agents/skills",
-	},
-	"claude": {
-		"user": "~/.claude/skills",
-		"repo": ".claude/skills",
-	},
-	"agents": {
-		"user": "~/.agents/skills",
-		"repo": ".agents/skills",
-	},
-}
-
-// ResolveInstallDir returns the skill installation directory for the given
-// agent and scope. An empty agent defaults to "claude"; an empty scope
-// defaults to "user".
-func ResolveInstallDir(agent, scope string) (string, error) {
-	if agent == "" {
-		agent = "claude"
-	}
-	if scope == "" {
-		scope = "user"
-	}
-
-	scopes, ok := agentScopePaths[agent]
-	if !ok {
-		return "", fmt.Errorf("unknown agent %q (supported: codex, claude, agents)", agent)
-	}
-
-	p, ok := scopes[scope]
-	if !ok {
-		return "", fmt.Errorf("unknown scope %q for agent %q (supported: user, repo)", scope, agent)
-	}
-
-	return expandHome(p)
+// DefaultInstallDir returns the default skill installation directory
+// (~/.agents/skills), which is the cross-client standard for agent skills.
+func DefaultInstallDir() (string, error) {
+	return expandHome("~/.agents/skills")
 }
 
 // expandHome replaces a leading "~" with the user's home directory and

--- a/resolve.go
+++ b/resolve.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"strings"
 )
 
 // InstallDirForScope returns the skill installation directory for the given
@@ -16,23 +15,14 @@ import (
 func InstallDirForScope(scope string) (string, error) {
 	switch scope {
 	case "", "user":
-		return expandHome("~/.agents/skills")
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return "", fmt.Errorf("resolving home directory: %w", err)
+		}
+		return filepath.Join(home, ".agents", "skills"), nil
 	case "repo":
-		return filepath.FromSlash(".agents/skills"), nil
+		return filepath.Join(".agents", "skills"), nil
 	default:
 		return "", fmt.Errorf("unknown scope %q (supported: user, repo)", scope)
 	}
-}
-
-// expandHome replaces a leading "~" with the user's home directory and
-// normalizes path separators for the current OS.
-func expandHome(p string) (string, error) {
-	if !strings.HasPrefix(p, "~") {
-		return filepath.FromSlash(p), nil
-	}
-	home, err := os.UserHomeDir()
-	if err != nil {
-		return "", fmt.Errorf("resolving home directory: %w", err)
-	}
-	return filepath.Join(home, p[1:]), nil
 }

--- a/resolve_test.go
+++ b/resolve_test.go
@@ -1,0 +1,65 @@
+package skillsmith
+
+import (
+	"os"
+	"testing"
+)
+
+func TestResolveInstallDir_Defaults(t *testing.T) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		t.Skip("cannot determine home directory:", err)
+	}
+
+	got, err := ResolveInstallDir("", "")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	want := home + "/.claude/skills"
+	if got != want {
+		t.Errorf("ResolveInstallDir(\"\",\"\") = %q, want %q", got, want)
+	}
+}
+
+func TestResolveInstallDir_AllMappings(t *testing.T) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		t.Skip("cannot determine home directory:", err)
+	}
+
+	tests := []struct {
+		agent, scope string
+		want         string
+	}{
+		{"codex", "user", home + "/.codex/skills"},
+		{"codex", "repo", ".agents/skills"},
+		{"claude", "user", home + "/.claude/skills"},
+		{"claude", "repo", ".claude/skills"},
+		{"agents", "user", home + "/.agents/skills"},
+		{"agents", "repo", ".agents/skills"},
+	}
+	for _, tt := range tests {
+		got, err := ResolveInstallDir(tt.agent, tt.scope)
+		if err != nil {
+			t.Errorf("ResolveInstallDir(%q,%q) error: %v", tt.agent, tt.scope, err)
+			continue
+		}
+		if got != tt.want {
+			t.Errorf("ResolveInstallDir(%q,%q) = %q, want %q", tt.agent, tt.scope, got, tt.want)
+		}
+	}
+}
+
+func TestResolveInstallDir_UnknownAgent(t *testing.T) {
+	_, err := ResolveInstallDir("unknown", "user")
+	if err == nil {
+		t.Error("expected error for unknown agent, got nil")
+	}
+}
+
+func TestResolveInstallDir_UnknownScope(t *testing.T) {
+	_, err := ResolveInstallDir("claude", "unknown")
+	if err == nil {
+		t.Error("expected error for unknown scope, got nil")
+	}
+}

--- a/resolve_test.go
+++ b/resolve_test.go
@@ -6,61 +6,18 @@ import (
 	"testing"
 )
 
-func TestResolveInstallDir_Defaults(t *testing.T) {
+func TestDefaultInstallDir(t *testing.T) {
 	home, err := os.UserHomeDir()
 	if err != nil {
 		t.Skip("cannot determine home directory:", err)
 	}
 
-	got, err := ResolveInstallDir("", "")
+	got, err := DefaultInstallDir()
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	want := filepath.Join(home, ".claude", "skills")
+	want := filepath.Join(home, ".agents", "skills")
 	if got != want {
-		t.Errorf("ResolveInstallDir(\"\",\"\") = %q, want %q", got, want)
-	}
-}
-
-func TestResolveInstallDir_AllMappings(t *testing.T) {
-	home, err := os.UserHomeDir()
-	if err != nil {
-		t.Skip("cannot determine home directory:", err)
-	}
-
-	tests := []struct {
-		agent, scope string
-		want         string
-	}{
-		{"codex", "user", filepath.Join(home, ".codex", "skills")},
-		{"codex", "repo", filepath.Join(".agents", "skills")},
-		{"claude", "user", filepath.Join(home, ".claude", "skills")},
-		{"claude", "repo", filepath.Join(".claude", "skills")},
-		{"agents", "user", filepath.Join(home, ".agents", "skills")},
-		{"agents", "repo", filepath.Join(".agents", "skills")},
-	}
-	for _, tt := range tests {
-		got, err := ResolveInstallDir(tt.agent, tt.scope)
-		if err != nil {
-			t.Errorf("ResolveInstallDir(%q,%q) error: %v", tt.agent, tt.scope, err)
-			continue
-		}
-		if got != tt.want {
-			t.Errorf("ResolveInstallDir(%q,%q) = %q, want %q", tt.agent, tt.scope, got, tt.want)
-		}
-	}
-}
-
-func TestResolveInstallDir_UnknownAgent(t *testing.T) {
-	_, err := ResolveInstallDir("unknown", "user")
-	if err == nil {
-		t.Error("expected error for unknown agent, got nil")
-	}
-}
-
-func TestResolveInstallDir_UnknownScope(t *testing.T) {
-	_, err := ResolveInstallDir("claude", "unknown")
-	if err == nil {
-		t.Error("expected error for unknown scope, got nil")
+		t.Errorf("DefaultInstallDir() = %q, want %q", got, want)
 	}
 }

--- a/resolve_test.go
+++ b/resolve_test.go
@@ -2,6 +2,7 @@ package skillsmith
 
 import (
 	"os"
+	"path/filepath"
 	"testing"
 )
 
@@ -15,7 +16,7 @@ func TestResolveInstallDir_Defaults(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	want := home + "/.claude/skills"
+	want := filepath.Join(home, ".claude", "skills")
 	if got != want {
 		t.Errorf("ResolveInstallDir(\"\",\"\") = %q, want %q", got, want)
 	}
@@ -31,12 +32,12 @@ func TestResolveInstallDir_AllMappings(t *testing.T) {
 		agent, scope string
 		want         string
 	}{
-		{"codex", "user", home + "/.codex/skills"},
-		{"codex", "repo", ".agents/skills"},
-		{"claude", "user", home + "/.claude/skills"},
-		{"claude", "repo", ".claude/skills"},
-		{"agents", "user", home + "/.agents/skills"},
-		{"agents", "repo", ".agents/skills"},
+		{"codex", "user", filepath.Join(home, ".codex", "skills")},
+		{"codex", "repo", filepath.Join(".agents", "skills")},
+		{"claude", "user", filepath.Join(home, ".claude", "skills")},
+		{"claude", "repo", filepath.Join(".claude", "skills")},
+		{"agents", "user", filepath.Join(home, ".agents", "skills")},
+		{"agents", "repo", filepath.Join(".agents", "skills")},
 	}
 	for _, tt := range tests {
 		got, err := ResolveInstallDir(tt.agent, tt.scope)

--- a/resolve_test.go
+++ b/resolve_test.go
@@ -6,18 +6,45 @@ import (
 	"testing"
 )
 
-func TestDefaultInstallDir(t *testing.T) {
+func TestInstallDirForScope_User(t *testing.T) {
 	home, err := os.UserHomeDir()
 	if err != nil {
 		t.Skip("cannot determine home directory:", err)
 	}
 
-	got, err := DefaultInstallDir()
+	tests := []struct {
+		scope string
+		want  string
+	}{
+		{"", filepath.Join(home, ".agents", "skills")},
+		{"user", filepath.Join(home, ".agents", "skills")},
+	}
+	for _, tt := range tests {
+		got, err := InstallDirForScope(tt.scope)
+		if err != nil {
+			t.Errorf("InstallDirForScope(%q) error: %v", tt.scope, err)
+			continue
+		}
+		if got != tt.want {
+			t.Errorf("InstallDirForScope(%q) = %q, want %q", tt.scope, got, tt.want)
+		}
+	}
+}
+
+func TestInstallDirForScope_Repo(t *testing.T) {
+	got, err := InstallDirForScope("repo")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	want := filepath.Join(home, ".agents", "skills")
+	want := filepath.Join(".agents", "skills")
 	if got != want {
-		t.Errorf("DefaultInstallDir() = %q, want %q", got, want)
+		t.Errorf("InstallDirForScope(\"repo\") = %q, want %q", got, want)
+	}
+}
+
+func TestInstallDirForScope_UnknownScope(t *testing.T) {
+	_, err := InstallDirForScope("unknown")
+	if err == nil {
+		t.Error("expected error for unknown scope, got nil")
 	}
 }

--- a/skills.go
+++ b/skills.go
@@ -1,0 +1,21 @@
+package skillsmith
+
+import (
+	"embed"
+	"io/fs"
+)
+
+//go:embed skills/**
+var skillsFS embed.FS
+
+// DemoFS returns the embedded demo skills filesystem with the "skills/"
+// prefix stripped so callers receive a top-level directory of skill dirs.
+func DemoFS() fs.FS {
+	sub, err := fs.Sub(skillsFS, "skills")
+	if err != nil {
+		// This can only happen if the embed path is wrong, which is a
+		// programming error caught at build time.
+		panic(err)
+	}
+	return sub
+}

--- a/skills/skillsmith-demo/SKILL.md
+++ b/skills/skillsmith-demo/SKILL.md
@@ -28,11 +28,11 @@ those skills in the user's agent environment.
 # List skills bundled with this tool
 mytool skills list
 
-# Install skills into the default agent directory (~/.claude/skills)
+# Install skills into the default skills directory (~/.agents/skills)
 mytool skills install
 
-# Install skills for a specific agent
-mytool skills install --agent codex --scope user
+# Install skills scoped to the current repository
+mytool skills install --scope repo
 
 # Install skills to a custom directory
 mytool skills install --prefix /path/to/skills

--- a/skills/skillsmith-demo/SKILL.md
+++ b/skills/skillsmith-demo/SKILL.md
@@ -1,0 +1,61 @@
+---
+name: skillsmith-demo
+description: Learn how to use skillsmith to distribute agent skills with your CLI
+license: MIT
+compatibility:
+  - claude
+  - codex
+  - agents
+allowed_tools:
+  - Bash
+  - Read
+---
+
+# skillsmith-demo
+
+`skillsmith` is a Go library that makes it easy to attach AI agent skill
+distribution to any existing CLI tool.
+
+## Overview
+
+skillsmith lets you embed `agentskills`-compatible skill files into your Go
+binary and expose an `skills` subcommand that installs, updates, and manages
+those skills in the user's agent environment.
+
+## Usage
+
+```bash
+# List skills bundled with this tool
+mytool skills list
+
+# Install skills into the default agent directory (~/.claude/skills)
+mytool skills install
+
+# Install skills for a specific agent
+mytool skills install --agent codex --scope user
+
+# Install skills to a custom directory
+mytool skills install --prefix /path/to/skills
+
+# Preview what would be installed without making changes
+mytool skills install --dry-run
+
+# Check which skills are installed and whether updates are available
+mytool skills status
+
+# Update skills whose version has changed
+mytool skills update
+
+# Reinstall all managed skills
+mytool skills reinstall
+
+# Remove all managed skills
+mytool skills uninstall
+```
+
+## Notes
+
+- Skills are installed alongside a `.skillsmith.json` metadata file that
+  records the installing tool, version, and timestamp.
+- Unmanaged skills (placed manually without `.skillsmith.json`) are never
+  overwritten unless `--force` is provided.

--- a/smith.go
+++ b/smith.go
@@ -37,8 +37,6 @@ var subcommands = []struct{ name, desc string }{
 }
 
 // Run parses args and dispatches to the matching subcommand.
-// Common flags (--dry-run, --prefix, --scope, --force) are parsed
-// before the subcommand is dispatched.
 func (s *Smith) Run(ctx context.Context, args []string) error {
 	out := s.outWriter()
 	errW := s.errWriter()

--- a/smith.go
+++ b/smith.go
@@ -1,0 +1,132 @@
+package skillsmith
+
+import (
+	"context"
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"io/fs"
+	"os"
+)
+
+// Smith is the main entry point for the skillsmith skills subcommand.
+// Embed an fs.FS containing skill directories and call Run to dispatch
+// to the appropriate subcommand.
+type Smith struct {
+	// FS holds the embedded or in-memory skill files.
+	FS fs.FS
+	// Version is the version string of the hosting CLI tool.
+	Version string
+	// Name is the name of the hosting CLI tool (written to .skillsmith.json).
+	Name string
+	// OutWriter is the writer for normal output (defaults to os.Stdout).
+	OutWriter io.Writer
+	// ErrWriter is the writer for error / diagnostic output (defaults to os.Stderr).
+	ErrWriter io.Writer
+}
+
+// subcommands lists the available subcommands and their one-line descriptions.
+var subcommands = []struct{ name, desc string }{
+	{"list", "list embedded skills"},
+	{"install", "install skills (skip existing)"},
+	{"update", "update skills when version differs"},
+	{"reinstall", "reinstall all managed skills"},
+	{"uninstall", "uninstall managed skills"},
+	{"status", "show install status and version diff"},
+}
+
+// Run parses args and dispatches to the matching subcommand.
+// Common flags (--dry-run, --prefix, --agent, --scope, --force) are parsed
+// before the subcommand is dispatched.
+func (s *Smith) Run(ctx context.Context, args []string) error {
+	out := s.outWriter()
+	errW := s.errWriter()
+
+	top := flag.NewFlagSet("skills", flag.ContinueOnError)
+	top.SetOutput(errW)
+	top.Usage = func() {
+		fmt.Fprintf(errW, "Usage: skills <command> [options]\n\n")
+		fmt.Fprintf(errW, "Commands:\n")
+		for _, cmd := range subcommands {
+			fmt.Fprintf(errW, "  %-12s %s\n", cmd.name, cmd.desc)
+		}
+		fmt.Fprintf(errW, "\nRun 'skills <command> --help' for command-specific options.\n")
+	}
+
+	// Parse only the subcommand name; let subcommand parsers handle the rest.
+	if err := top.Parse(args); err != nil {
+		if errors.Is(err, flag.ErrHelp) {
+			return nil
+		}
+		return err
+	}
+
+	subArgs := top.Args()
+	if len(subArgs) == 0 {
+		top.Usage()
+		return nil
+	}
+
+	subcmd := subArgs[0]
+	rest := subArgs[1:]
+
+	switch subcmd {
+	case "list":
+		return s.cmdList(ctx, rest, out, errW)
+	case "install":
+		return s.cmdInstall(ctx, rest, out, errW)
+	case "update":
+		return s.cmdUpdate(ctx, rest, out, errW)
+	case "reinstall":
+		return s.cmdReinstall(ctx, rest, out, errW)
+	case "uninstall":
+		return s.cmdUninstall(ctx, rest, out, errW)
+	case "status":
+		return s.cmdStatus(ctx, rest, out, errW)
+	default:
+		fmt.Fprintf(errW, "unknown subcommand %q\n\n", subcmd)
+		top.Usage()
+		return fmt.Errorf("unknown subcommand %q", subcmd)
+	}
+}
+
+// commonFlags holds flags shared by most subcommands.
+type commonFlags struct {
+	dryRun bool
+	prefix string
+	agent  string
+	scope  string
+	force  bool
+}
+
+// addCommonFlags registers the common flags onto fs.
+func addCommonFlags(f *flag.FlagSet, cf *commonFlags) {
+	f.BoolVar(&cf.dryRun, "dry-run", false, "print what would happen without making changes")
+	f.StringVar(&cf.prefix, "prefix", "", "skill installation directory (overrides --agent/--scope)")
+	f.StringVar(&cf.agent, "agent", "", "target agent: codex, claude, agents (default: claude)")
+	f.StringVar(&cf.scope, "scope", "", "target scope: user, repo (default: user)")
+	f.BoolVar(&cf.force, "force", false, "overwrite unmanaged skills")
+}
+
+// installDir returns the effective installation directory for the given flags.
+func (s *Smith) installDir(cf commonFlags) (string, error) {
+	if cf.prefix != "" {
+		return cf.prefix, nil
+	}
+	return ResolveInstallDir(cf.agent, cf.scope)
+}
+
+func (s *Smith) outWriter() io.Writer {
+	if s.OutWriter != nil {
+		return s.OutWriter
+	}
+	return os.Stdout
+}
+
+func (s *Smith) errWriter() io.Writer {
+	if s.ErrWriter != nil {
+		return s.ErrWriter
+	}
+	return os.Stderr
+}

--- a/smith.go
+++ b/smith.go
@@ -37,7 +37,7 @@ var subcommands = []struct{ name, desc string }{
 }
 
 // Run parses args and dispatches to the matching subcommand.
-// Common flags (--dry-run, --prefix, --agent, --scope, --force) are parsed
+// Common flags (--dry-run, --prefix, --force) are parsed
 // before the subcommand is dispatched.
 func (s *Smith) Run(ctx context.Context, args []string) error {
 	out := s.outWriter()
@@ -95,17 +95,13 @@ func (s *Smith) Run(ctx context.Context, args []string) error {
 type commonFlags struct {
 	dryRun bool
 	prefix string
-	agent  string
-	scope  string
 	force  bool
 }
 
 // addCommonFlags registers the common flags onto fs.
 func addCommonFlags(f *flag.FlagSet, cf *commonFlags) {
 	f.BoolVar(&cf.dryRun, "dry-run", false, "print what would happen without making changes")
-	f.StringVar(&cf.prefix, "prefix", "", "skill installation directory (overrides --agent/--scope)")
-	f.StringVar(&cf.agent, "agent", "", "target agent: codex, claude, agents (default: claude)")
-	f.StringVar(&cf.scope, "scope", "", "target scope: user, repo (default: user)")
+	f.StringVar(&cf.prefix, "prefix", "", "skill installation directory (default: ~/.agents/skills)")
 	f.BoolVar(&cf.force, "force", false, "overwrite unmanaged skills")
 }
 
@@ -114,7 +110,7 @@ func (s *Smith) installDir(cf commonFlags) (string, error) {
 	if cf.prefix != "" {
 		return cf.prefix, nil
 	}
-	return ResolveInstallDir(cf.agent, cf.scope)
+	return DefaultInstallDir()
 }
 
 func (s *Smith) outWriter() io.Writer {

--- a/smith.go
+++ b/smith.go
@@ -37,7 +37,7 @@ var subcommands = []struct{ name, desc string }{
 }
 
 // Run parses args and dispatches to the matching subcommand.
-// Common flags (--dry-run, --prefix, --force) are parsed
+// Common flags (--dry-run, --prefix, --scope, --force) are parsed
 // before the subcommand is dispatched.
 func (s *Smith) Run(ctx context.Context, args []string) error {
 	out := s.outWriter()
@@ -95,22 +95,25 @@ func (s *Smith) Run(ctx context.Context, args []string) error {
 type commonFlags struct {
 	dryRun bool
 	prefix string
+	scope  string
 	force  bool
 }
 
 // addCommonFlags registers the common flags onto fs.
 func addCommonFlags(f *flag.FlagSet, cf *commonFlags) {
 	f.BoolVar(&cf.dryRun, "dry-run", false, "print what would happen without making changes")
-	f.StringVar(&cf.prefix, "prefix", "", "skill installation directory (default: ~/.agents/skills)")
+	f.StringVar(&cf.prefix, "prefix", "", "skill installation directory (overrides --scope)")
+	f.StringVar(&cf.scope, "scope", "", "target scope: user (~/.agents/skills, default) or repo (.agents/skills)")
 	f.BoolVar(&cf.force, "force", false, "overwrite unmanaged skills")
 }
 
 // installDir returns the effective installation directory for the given flags.
+// --prefix takes precedence; otherwise the directory is derived from --scope.
 func (s *Smith) installDir(cf commonFlags) (string, error) {
 	if cf.prefix != "" {
 		return cf.prefix, nil
 	}
-	return DefaultInstallDir()
+	return InstallDirForScope(cf.scope)
 }
 
 func (s *Smith) outWriter() io.Writer {

--- a/smith_test.go
+++ b/smith_test.go
@@ -1,0 +1,159 @@
+package skillsmith
+
+import (
+	"bytes"
+	"context"
+	"strings"
+	"testing"
+	"testing/fstest"
+)
+
+var testSkillFS = fstest.MapFS{
+	"demo-skill/SKILL.md": {
+		Data: []byte(`---
+name: demo-skill
+description: A demonstration skill
+license: MIT
+---
+# demo-skill
+
+Teaches the agent how to use demo.
+`),
+	},
+}
+
+func newTestSmith(fsys fstest.MapFS) (*Smith, *bytes.Buffer, *bytes.Buffer) {
+	out := &bytes.Buffer{}
+	errW := &bytes.Buffer{}
+	s := &Smith{
+		FS:        fsys,
+		Version:   "v1.0.0",
+		Name:      "testtool",
+		OutWriter: out,
+		ErrWriter: errW,
+	}
+	return s, out, errW
+}
+
+func TestSmith_Run_UnknownSubcommand(t *testing.T) {
+	s, _, _ := newTestSmith(testSkillFS)
+	err := s.Run(context.Background(), []string{"unknown"})
+	if err == nil {
+		t.Error("expected error for unknown subcommand, got nil")
+	}
+}
+
+func TestSmith_Run_NoArgs(t *testing.T) {
+	s, _, _ := newTestSmith(testSkillFS)
+	err := s.Run(context.Background(), []string{})
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+func TestSmith_Run_Help(t *testing.T) {
+	s, _, errW := newTestSmith(testSkillFS)
+	err := s.Run(context.Background(), []string{"--help"})
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+	if !strings.Contains(errW.String(), "install") {
+		t.Errorf("help output does not mention 'install', got: %q", errW.String())
+	}
+}
+
+func TestSmith_List(t *testing.T) {
+	s, out, _ := newTestSmith(testSkillFS)
+	err := s.Run(context.Background(), []string{"list"})
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	if !strings.Contains(out.String(), "demo-skill") {
+		t.Errorf("list output missing 'demo-skill', got: %q", out.String())
+	}
+}
+
+func TestSmith_Install_DryRun(t *testing.T) {
+	s, out, _ := newTestSmith(testSkillFS)
+	dir := t.TempDir()
+	err := s.Run(context.Background(), []string{"install", "--prefix", dir, "--dry-run"})
+	if err != nil {
+		t.Fatalf("install --dry-run: %v", err)
+	}
+	if !strings.Contains(out.String(), "dry-run") {
+		t.Errorf("dry-run output missing indicator, got: %q", out.String())
+	}
+}
+
+func TestSmith_Install_ThenStatus(t *testing.T) {
+	s, out, _ := newTestSmith(testSkillFS)
+	dir := t.TempDir()
+
+	// Install.
+	if err := s.Run(context.Background(), []string{"install", "--prefix", dir}); err != nil {
+		t.Fatalf("install: %v", err)
+	}
+
+	// Status.
+	out.Reset()
+	if err := s.Run(context.Background(), []string{"status", "--prefix", dir}); err != nil {
+		t.Fatalf("status: %v", err)
+	}
+	if !strings.Contains(out.String(), "demo-skill") {
+		t.Errorf("status output missing 'demo-skill', got: %q", out.String())
+	}
+	if !strings.Contains(out.String(), "up to date") {
+		t.Errorf("status output should show 'up to date', got: %q", out.String())
+	}
+}
+
+func TestSmith_Uninstall(t *testing.T) {
+	s, out, _ := newTestSmith(testSkillFS)
+	dir := t.TempDir()
+
+	if err := s.Run(context.Background(), []string{"install", "--prefix", dir}); err != nil {
+		t.Fatalf("install: %v", err)
+	}
+
+	out.Reset()
+	if err := s.Run(context.Background(), []string{"uninstall", "--prefix", dir}); err != nil {
+		t.Fatalf("uninstall: %v", err)
+	}
+	if !strings.Contains(out.String(), "uninstalled") {
+		t.Errorf("uninstall output missing 'uninstalled', got: %q", out.String())
+	}
+}
+
+func TestSmith_Update_NoChange(t *testing.T) {
+	s, out, _ := newTestSmith(testSkillFS)
+	dir := t.TempDir()
+
+	if err := s.Run(context.Background(), []string{"install", "--prefix", dir}); err != nil {
+		t.Fatalf("install: %v", err)
+	}
+
+	out.Reset()
+	if err := s.Run(context.Background(), []string{"update", "--prefix", dir}); err != nil {
+		t.Fatalf("update: %v", err)
+	}
+	if !strings.Contains(out.String(), "skipped") {
+		t.Errorf("update with same version should skip, got: %q", out.String())
+	}
+}
+
+func TestSmith_Reinstall(t *testing.T) {
+	s, out, _ := newTestSmith(testSkillFS)
+	dir := t.TempDir()
+
+	if err := s.Run(context.Background(), []string{"install", "--prefix", dir}); err != nil {
+		t.Fatalf("install: %v", err)
+	}
+
+	out.Reset()
+	if err := s.Run(context.Background(), []string{"reinstall", "--prefix", dir}); err != nil {
+		t.Fatalf("reinstall: %v", err)
+	}
+	if !strings.Contains(out.String(), "reinstalled") {
+		t.Errorf("reinstall output missing 'reinstalled', got: %q", out.String())
+	}
+}

--- a/version.go
+++ b/version.go
@@ -3,3 +3,8 @@ package skillsmith
 const version = "0.0.0"
 
 var revision = "HEAD"
+
+// Version returns the current version string.
+func Version() string {
+	return version
+}


### PR DESCRIPTION
## Overview

Implement the core functionality of skillsmith.

### Implementation Plan

1. **`agentskill` subpackage** — SKILL.md parsing, lenient validation, skill discovery from `fs.FS`
2. **Install path resolution** — `InstallDirForScope()` with `user`→`~/.agents/skills` and `repo`→`.agents/skills`; custom path via `--prefix`
3. **Metadata management** — `.skillsmith.json` read/write
4. **Skill distribution layer** — Copy from `fs.FS` to disk with install/update/reinstall rules; atomic overwrite via backup-rename
5. **Smith struct + command layer** — `Run(ctx, args)`, 6 subcommands, standard flag package
6. **Demo binary** — Update `cmd/skillsmith` with sample skills
7. **Documentation** — Update README.md and SKETCH.md

### Design

See SKETCH.md for the full design specification.

---

## Detailed Implementation

### `agentskill/` subpackage
- **`skill.go`** — `Skill` struct (Name, Description, License, Compatibility, Metadata, AllowedTools, Body, Dir) and `Parse(r io.Reader) (*Skill, error)` using `github.com/goccy/go-yaml` for YAML frontmatter between `---` delimiters
- **`validate.go`** — `Validate(s, dirName)` returning `ValidationResult{Warnings, Errors}`: name mismatch/length>64 → Warning; missing description/unparseable YAML → Error
- **`error.go`** — `SkillError{Dir, Err}` type implementing `error` and `Unwrap()`; callers can use `errors.As` to extract the per-skill directory from any error in the chain
- **`discover.go`** — `Discover(fsys fs.FS) ([]*Skill, error)` enumerating skill subdirectories from an `fs.FS`; per-skill failures are collected as `*SkillError` values joined via `errors.Join`
- Tests using `testing/fstest.MapFS`

### Install path resolution (`resolve.go`)
- `InstallDirForScope(scope string) (string, error)` mapping `user`/empty → `~/.agents/skills`, `repo` → `.agents/skills`
- `os.UserHomeDir()` called directly inside `InstallDirForScope` (no `expandHome` helper)
- No `--agent` flag; resolution is: `--prefix <dir>` → use directly; `--scope repo` → `.agents/skills`; `--scope user` or no flags → `~/.agents/skills`

### Metadata management (`metadata.go`)
- `SkillMeta` struct, `ReadMeta`/`WriteMeta`/`IsManaged` operating on `.skillsmith.json` with camelCase JSON keys (`installedBy`, `version`, `installedAt`)

### Skill distribution layer (`copy.go`)
- `CopySkills(src fs.FS, destDir string, opts CopyOptions) (*CopyResult, error)`
- `CopyOptions`: Mode (install/update/reinstall), Force, DryRun, Name, Version
- Implements the SKETCH.md judgment matrix; writes `.skillsmith.json` on successful copy
- `CopyResult` with `Installed()`/`Skipped()`/`Warned()` helpers
- `eachError(err, fn)` helper to iterate over a potentially joined error; used to extract `*SkillError.Dir` so `CopyResult` warnings carry the correct skill directory
- **Atomic overwrite via backup-rename**: when overwriting an existing skill directory (update/reinstall/force-install), the existing directory is renamed to `<dir>.<rand>.bak` (random hex suffix) before copying; on success the backup is deleted, on failure the backup is restored — prevents stale files from persisting across updates, ensures rollback safety if the copy fails, and avoids collisions with any leftover backup from a prior interrupted install

### Smith struct + command layer
- **`smith.go`** — `Smith{FS, Version, Name, OutWriter, ErrWriter}` with `Run(ctx, args)`, custom `flag.FlagSet.Usage` showing subcommand list, common flags (`--dry-run`, `--prefix`, `--scope`, `--force`)
- **`cmd_list.go`**, **`cmd_install.go`**, **`cmd_update.go`**, **`cmd_reinstall.go`**, **`cmd_uninstall.go`**, **`cmd_status.go`**
- Dry-run output uses `<action> (dry-run): <dir>` format (e.g. `installed (dry-run): my-skill`, `uninstalled (dry-run): my-skill`) for clarity across all subcommands, followed by a `[dry-run] no changes were made` footer

### Demo binary (`cmd/skillsmith`)
- **`skills.go`** in root package — embeds `skills/**` and exports `DemoFS()` (prefix stripped)
- **`skills/skillsmith-demo/SKILL.md`** — valid agentskills frontmatter with usage examples
- **`cmd/skillsmith/main.go`** — dispatches `skills` subcommand via `Smith`; existing `skillsmith.Run` and `version.go` retained

### Documentation
- **`README.md`** — updated with `Smith` usage synopsis, feature description, and command examples
- **`SKETCH.md`** — updated to reflect simplified install path resolution: removed `--agent` and agent/scope mapping table; `--scope` retained with `user`/`repo` values mapping to `.agents/skills` paths

<!-- START COPILOT CODING AGENT TIPS -->
---

💬 Send tasks to Copilot coding agent from [Slack](https://gh.io/cca-slack-docs) and [Teams](https://gh.io/cca-teams-docs) to turn conversations into code. Copilot posts an update in your thread when it's finished.