### PR TITLE
Auto-detect skills root directory in FS

### DIFF
--- a/cmd_install.go
+++ b/cmd_install.go
@@ -25,7 +25,7 @@ func (s *Smith) cmdInstall(_ context.Context, args []string, out, errW io.Writer
 		return err
 	}
 
-	result, err := CopySkills(s.FS, dir, CopyOptions{
+	result, err := CopySkills(s.skillsFS(), dir, CopyOptions{
 		Mode:    ModeInstall,
 		Force:   cf.force,
 		DryRun:  cf.dryRun,

--- a/cmd_list.go
+++ b/cmd_list.go
@@ -20,7 +20,7 @@ func (s *Smith) cmdList(_ context.Context, args []string, out, errW io.Writer) e
 		return err
 	}
 
-	skills, discoverErr := agentskill.Discover(s.FS)
+	skills, discoverErr := agentskill.Discover(s.skillsFS())
 	var fatalErr error
 	eachError(discoverErr, func(e error) {
 		var se *agentskill.SkillError

--- a/cmd_reinstall.go
+++ b/cmd_reinstall.go
@@ -25,7 +25,7 @@ func (s *Smith) cmdReinstall(_ context.Context, args []string, out, errW io.Writ
 		return err
 	}
 
-	result, err := CopySkills(s.FS, dir, CopyOptions{
+	result, err := CopySkills(s.skillsFS(), dir, CopyOptions{
 		Mode:    ModeReinstall,
 		Force:   cf.force,
 		DryRun:  cf.dryRun,

--- a/cmd_status.go
+++ b/cmd_status.go
@@ -28,7 +28,7 @@ func (s *Smith) cmdStatus(_ context.Context, args []string, out, errW io.Writer)
 		return err
 	}
 
-	skills, discoverErr := agentskill.Discover(s.FS)
+	skills, discoverErr := agentskill.Discover(s.skillsFS())
 	var fatalErr error
 	eachError(discoverErr, func(e error) {
 		var se *agentskill.SkillError

--- a/cmd_uninstall.go
+++ b/cmd_uninstall.go
@@ -29,7 +29,7 @@ func (s *Smith) cmdUninstall(_ context.Context, args []string, out, errW io.Writ
 		return err
 	}
 
-	skills, discoverErr := agentskill.Discover(s.FS)
+	skills, discoverErr := agentskill.Discover(s.skillsFS())
 	if discoverErr != nil {
 		var skillErr *agentskill.SkillError
 		if !errors.As(discoverErr, &skillErr) {

--- a/cmd_update.go
+++ b/cmd_update.go
@@ -25,7 +25,7 @@ func (s *Smith) cmdUpdate(_ context.Context, args []string, out, errW io.Writer)
 		return err
 	}
 
-	result, err := CopySkills(s.FS, dir, CopyOptions{
+	result, err := CopySkills(s.skillsFS(), dir, CopyOptions{
 		Mode:    ModeUpdate,
 		Force:   cf.force,
 		DryRun:  cf.dryRun,

--- a/skills.go
+++ b/skills.go
@@ -8,14 +8,8 @@ import (
 //go:embed skills/**
 var skillsFS embed.FS
 
-// DemoFS returns the embedded demo skills filesystem with the "skills/"
-// prefix stripped so callers receive a top-level directory of skill dirs.
+// DemoFS returns the embedded demo skills filesystem.
+// The "skills/" prefix is stripped automatically by Smith.skillsFS().
 func DemoFS() fs.FS {
-	sub, err := fs.Sub(skillsFS, "skills")
-	if err != nil {
-		// This can only happen if the embed path is wrong, which is a
-		// programming error caught at build time.
-		panic(err)
-	}
-	return sub
+	return skillsFS
 }

--- a/smith.go
+++ b/smith.go
@@ -30,10 +30,11 @@ type Smith struct {
 	skillsFSVal  fs.FS
 }
 
-// skillsFS returns the effective skills FS. If the root of s.FS contains
-// exactly one directory named "skills" and no files, it is treated as an
-// embed container prefix and stripped via fs.Sub. Otherwise s.FS is used
-// as-is. The result is cached after the first call.
+// skillsFS returns the effective skills FS. If the root of s.FS contains a
+// directory named "skills" (and no other directories), it is treated as an
+// embed container prefix and stripped via fs.Sub. Files at root are ignored
+// for this check. Otherwise s.FS is used as-is.
+// The result is cached after the first call.
 func (s *Smith) skillsFS() fs.FS {
 	s.skillsFSOnce.Do(func() {
 		entries, err := fs.ReadDir(s.FS, ".")
@@ -45,11 +46,8 @@ func (s *Smith) skillsFS() fs.FS {
 		for _, e := range entries {
 			if e.IsDir() {
 				dirs = append(dirs, e.Name())
-			} else {
-				// A file at root means we should use s.FS as-is.
-				s.skillsFSVal = s.FS
-				return
 			}
+			// Files at root are ignored: e.g. README.md alongside skills/.
 		}
 		// Only strip when there is exactly one directory and it is named "skills".
 		// Any other name indicates the directory is itself a skill, not a container.

--- a/smith.go
+++ b/smith.go
@@ -31,10 +31,9 @@ type Smith struct {
 }
 
 // skillsFS returns the effective skills FS. If the root of s.FS contains
-// exactly one directory and no files, AND that directory itself contains only
-// subdirectories (not files), it is treated as an embed container prefix and
-// stripped via fs.Sub. Otherwise s.FS is used as-is.
-// The result is cached after the first call.
+// exactly one directory named "skills" and no files, it is treated as an
+// embed container prefix and stripped via fs.Sub. Otherwise s.FS is used
+// as-is. The result is cached after the first call.
 func (s *Smith) skillsFS() fs.FS {
 	s.skillsFSOnce.Do(func() {
 		entries, err := fs.ReadDir(s.FS, ".")
@@ -52,33 +51,13 @@ func (s *Smith) skillsFS() fs.FS {
 				return
 			}
 		}
-		if len(dirs) != 1 {
+		// Only strip when there is exactly one directory and it is named "skills".
+		// Any other name indicates the directory is itself a skill, not a container.
+		if len(dirs) != 1 || dirs[0] != "skills" {
 			s.skillsFSVal = s.FS
 			return
 		}
-		// There is exactly one directory at root. Check whether it looks like
-		// a container (holds only subdirs) rather than a skill dir (holds files).
-		inner, err := fs.ReadDir(s.FS, dirs[0])
-		if err != nil {
-			s.skillsFSVal = s.FS
-			return
-		}
-		if len(inner) == 0 {
-			// Empty directory: cannot determine intent, use s.FS as-is.
-			s.skillsFSVal = s.FS
-			return
-		}
-		for _, e := range inner {
-			if !e.IsDir() {
-				// The single root dir contains files — it is itself a skill
-				// directory, not a container. Use s.FS as-is.
-				s.skillsFSVal = s.FS
-				return
-			}
-		}
-		// The single root dir contains only subdirectories: treat it as an
-		// embed prefix and strip it.
-		sub, err := fs.Sub(s.FS, dirs[0])
+		sub, err := fs.Sub(s.FS, "skills")
 		if err != nil {
 			s.skillsFSVal = s.FS
 			return

--- a/smith.go
+++ b/smith.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"io/fs"
 	"os"
+	"sync"
 )
 
 // Smith is the main entry point for the skillsmith skills subcommand.
@@ -24,6 +25,67 @@ type Smith struct {
 	OutWriter io.Writer
 	// ErrWriter is the writer for error / diagnostic output (defaults to os.Stderr).
 	ErrWriter io.Writer
+
+	skillsFSOnce sync.Once
+	skillsFSVal  fs.FS
+}
+
+// skillsFS returns the effective skills FS. If the root of s.FS contains
+// exactly one directory and no files, AND that directory itself contains only
+// subdirectories (not files), it is treated as an embed container prefix and
+// stripped via fs.Sub. Otherwise s.FS is used as-is.
+// The result is cached after the first call.
+func (s *Smith) skillsFS() fs.FS {
+	s.skillsFSOnce.Do(func() {
+		entries, err := fs.ReadDir(s.FS, ".")
+		if err != nil {
+			s.skillsFSVal = s.FS
+			return
+		}
+		var dirs []string
+		for _, e := range entries {
+			if e.IsDir() {
+				dirs = append(dirs, e.Name())
+			} else {
+				// A file at root means we should use s.FS as-is.
+				s.skillsFSVal = s.FS
+				return
+			}
+		}
+		if len(dirs) != 1 {
+			s.skillsFSVal = s.FS
+			return
+		}
+		// There is exactly one directory at root. Check whether it looks like
+		// a container (holds only subdirs) rather than a skill dir (holds files).
+		inner, err := fs.ReadDir(s.FS, dirs[0])
+		if err != nil {
+			s.skillsFSVal = s.FS
+			return
+		}
+		if len(inner) == 0 {
+			// Empty directory: cannot determine intent, use s.FS as-is.
+			s.skillsFSVal = s.FS
+			return
+		}
+		for _, e := range inner {
+			if !e.IsDir() {
+				// The single root dir contains files — it is itself a skill
+				// directory, not a container. Use s.FS as-is.
+				s.skillsFSVal = s.FS
+				return
+			}
+		}
+		// The single root dir contains only subdirectories: treat it as an
+		// embed prefix and strip it.
+		sub, err := fs.Sub(s.FS, dirs[0])
+		if err != nil {
+			s.skillsFSVal = s.FS
+			return
+		}
+		s.skillsFSVal = sub
+	})
+	return s.skillsFSVal
 }
 
 // subcommands lists the available subcommands and their one-line descriptions.

--- a/smith_test.go
+++ b/smith_test.go
@@ -175,10 +175,29 @@ Teaches the agent how to use demo.
 	},
 }
 
-// mixedRootFS has both a directory and a file at root.
+// mixedRootFS has a file at root alongside a non-"skills" directory.
+// The file is ignored for detection; the dir is not named "skills", so the FS
+// is used as-is.
 var mixedRootFS = fstest.MapFS{
 	"README.md": {Data: []byte("readme")},
 	"demo-skill/SKILL.md": {
+		Data: []byte(`---
+name: demo-skill
+description: A demonstration skill
+license: MIT
+---
+# demo-skill
+
+Teaches the agent how to use demo.
+`),
+	},
+}
+
+// wrappedWithFileFS wraps skills under "skills/" and also has a README.md at root,
+// simulating an embed FS where files coexist with the skills container dir.
+var wrappedWithFileFS = fstest.MapFS{
+	"README.md": {Data: []byte("readme")},
+	"skills/demo-skill/SKILL.md": {
 		Data: []byte(`---
 name: demo-skill
 description: A demonstration skill
@@ -237,8 +256,33 @@ func TestSkillsFS_PreStripped_UsesAsIs(t *testing.T) {
 func TestSkillsFS_MixedRoot_UsesAsIs(t *testing.T) {
 	s := &Smith{FS: mixedRootFS}
 	detected := s.skillsFS()
-	// Mixed root (files + dirs) should return the FS as-is; README.md must be visible.
+	// The only directory is "demo-skill" (not "skills"), so the FS is used as-is.
+	// README.md must still be visible at root.
 	if _, err := fs.Stat(detected, "README.md"); err != nil {
 		t.Errorf("expected README.md at root of skillsFS() for mixed-root FS, got: %v", err)
+	}
+}
+
+func TestSkillsFS_SkillsDirWithFileAtRoot_AutoDetects(t *testing.T) {
+	s := &Smith{FS: wrappedWithFileFS}
+	detected := s.skillsFS()
+	// Files at root (e.g. README.md) are ignored; "skills/" is still stripped.
+	entries, err := fs.ReadDir(detected, ".")
+	if err != nil {
+		t.Fatalf("ReadDir: %v", err)
+	}
+	for _, e := range entries {
+		if e.Name() == "skills" {
+			t.Error("skillsFS() should have stripped the 'skills/' prefix, but 'skills' dir still present at root")
+		}
+	}
+	found := false
+	for _, e := range entries {
+		if e.Name() == "demo-skill" {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected 'demo-skill' at root of skillsFS(), got entries: %v", entries)
 	}
 }

--- a/smith_test.go
+++ b/smith_test.go
@@ -3,6 +3,7 @@ package skillsmith
 import (
 	"bytes"
 	"context"
+	"io/fs"
 	"strings"
 	"testing"
 	"testing/fstest"
@@ -155,5 +156,89 @@ func TestSmith_Reinstall(t *testing.T) {
 	}
 	if !strings.Contains(out.String(), "reinstalled") {
 		t.Errorf("reinstall output missing 'reinstalled', got: %q", out.String())
+	}
+}
+
+// wrappedSkillFS wraps testSkillFS under a "skills/" directory to simulate
+// what //go:embed skills/** produces.
+var wrappedSkillFS = fstest.MapFS{
+	"skills/demo-skill/SKILL.md": {
+		Data: []byte(`---
+name: demo-skill
+description: A demonstration skill
+license: MIT
+---
+# demo-skill
+
+Teaches the agent how to use demo.
+`),
+	},
+}
+
+// mixedRootFS has both a directory and a file at root.
+var mixedRootFS = fstest.MapFS{
+	"README.md": {Data: []byte("readme")},
+	"demo-skill/SKILL.md": {
+		Data: []byte(`---
+name: demo-skill
+description: A demonstration skill
+license: MIT
+---
+# demo-skill
+
+Teaches the agent how to use demo.
+`),
+	},
+}
+
+func TestSkillsFS_SingleDir_AutoDetects(t *testing.T) {
+	s := &Smith{FS: wrappedSkillFS}
+	detected := s.skillsFS()
+	entries, err := fs.ReadDir(detected, ".")
+	if err != nil {
+		t.Fatalf("ReadDir: %v", err)
+	}
+	for _, e := range entries {
+		if e.Name() == "skills" {
+			t.Error("skillsFS() should have stripped the 'skills/' prefix, but 'skills' dir still present at root")
+		}
+	}
+	// demo-skill should be visible at root of the detected FS.
+	found := false
+	for _, e := range entries {
+		if e.Name() == "demo-skill" {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected 'demo-skill' at root of skillsFS(), got entries: %v", entries)
+	}
+}
+
+func TestSkillsFS_PreStripped_UsesAsIs(t *testing.T) {
+	s := &Smith{FS: testSkillFS}
+	detected := s.skillsFS()
+	entries, err := fs.ReadDir(detected, ".")
+	if err != nil {
+		t.Fatalf("ReadDir: %v", err)
+	}
+	// demo-skill should be at root directly (already stripped).
+	found := false
+	for _, e := range entries {
+		if e.Name() == "demo-skill" {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected 'demo-skill' at root of skillsFS(), got entries: %v", entries)
+	}
+}
+
+func TestSkillsFS_MixedRoot_UsesAsIs(t *testing.T) {
+	s := &Smith{FS: mixedRootFS}
+	detected := s.skillsFS()
+	// Mixed root (files + dirs) should return the FS as-is; README.md must be visible.
+	if _, err := fs.Stat(detected, "README.md"); err != nil {
+		t.Errorf("expected README.md at root of skillsFS() for mixed-root FS, got: %v", err)
 	}
 }


### PR DESCRIPTION
## Problem

Users currently need to call `fs.Sub(skillsFS, "skills")` to strip the embed prefix before passing the FS to `Smith`. This is not user-friendly.

## Solution

Auto-detect the skills root: when the FS root contains a directory named `"skills"` as its only directory (files at root such as `README.md` are ignored), it is treated as an embed container prefix and automatically stripped via `fs.Sub`. If the single root directory has any other name, it is considered a skill directory itself and the FS is used as-is.

This makes both of the following work — passing `embed.FS` directly or pre-stripped via `fs.Sub`.

## Changes

- **`smith.go`**: Added `skillsFS()` method with `sync.Once` caching. Strips the root prefix only when there is exactly one directory at root named `"skills"` (files at root are ignored); otherwise returns `s.FS` as-is.
- **`cmd_list.go`, `cmd_install.go`, `cmd_update.go`, `cmd_reinstall.go`, `cmd_status.go`, `cmd_uninstall.go`**: All updated to use `s.skillsFS()` instead of `s.FS` directly.
- **`skills.go`**: Simplified `DemoFS()` to return the raw `embed.FS` — the `Smith` strips the prefix automatically.
- **`smith_test.go`**: Added tests covering single-directory auto-detection (`skills/` prefix stripped), pre-stripped FS (used as-is), non-"skills" dir alongside files (used as-is), and `skills/` dir with a `README.md` at root (auto-detects and strips).

<!-- START COPILOT CODING AGENT TIPS -->
---

💡 You can make Copilot smarter by setting up custom instructions, customizing its development environment and configuring Model Context Protocol (MCP) servers. Learn more [Copilot coding agent tips](https://gh.io/copilot-coding-agent-tips) in the docs.