### PR TITLE
Find repo root for --scope repo

### DIFF
--- a/SKETCH.md
+++ b/SKETCH.md
@@ -131,7 +131,7 @@ mytool skills uninstall
 |-----------|------|------|
 | `--dry-run` | | 実際の変更を行わず、何が行われるかを表示する |
 | `--prefix` | | スキルのインストール先ディレクトリを直接指定（指定時は `--scope` を無視） |
-| `--scope` | | `user`（既定: `~/.agents/skills`）または `repo`（`.agents/skills`） |
+| `--scope` | | `user`（既定: `~/.agents/skills`）または `repo`（リポジトリルート自動検出: `<repo-root>/.agents/skills`） |
 | `--force` | | 管理外スキルの上書きを許可 |
 | `--help` | `-h` | ヘルプを表示 |
 
@@ -150,7 +150,7 @@ mytool skills uninstall
 ### 解決の優先順位
 
 1. `--prefix <dir>` — 指定時はその値を使用する（`--scope` は無視される）
-2. `--scope repo` — `.agents/skills`（カレントディレクトリ基準）
+2. `--scope repo` — `<repo-root>/.agents/skills`（親ディレクトリを `.git` が見つかるまで遡ってリポジトリルートを自動検出）
 3. `--scope user`（または指定なし） — `~/.agents/skills`
 
 ### 将来検討

--- a/resolve.go
+++ b/resolve.go
@@ -28,6 +28,12 @@ func findRepoRoot() (string, error) {
 			if mode.IsDir() || mode.IsRegular() {
 				return dir, nil
 			}
+			// If .git exists but is neither a directory nor a regular file,
+			// treat this as a hard error instead of silently continuing upward.
+			if mode&os.ModeSymlink != 0 {
+				return "", fmt.Errorf(".git in %s is a symlink, which is not supported for security reasons", dir)
+			}
+			return "", fmt.Errorf(".git in %s has unsupported file type (mode: %v)", dir, mode)
 		} else if !errors.Is(err, os.ErrNotExist) {
 			return "", fmt.Errorf("checking .git in %s: %w", dir, err)
 		}

--- a/resolve.go
+++ b/resolve.go
@@ -1,17 +1,51 @@
 package skillsmith
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
 )
 
+// FindRepoRoot traverses parent directories from the current working directory
+// to find the repository root (the directory containing a .git entry).
+//
+// It uses os.Lstat to avoid following symlinks: .git must be a directory
+// (normal repo) or a regular file (git worktree). A symlink named .git is
+// ignored for security.
+//
+// Returns an error if the filesystem root is reached without finding .git.
+func FindRepoRoot() (string, error) {
+	dir, err := os.Getwd()
+	if err != nil {
+		return "", fmt.Errorf("getting current directory: %w", err)
+	}
+
+	for {
+		fi, err := os.Lstat(filepath.Join(dir, ".git"))
+		if err == nil {
+			mode := fi.Mode()
+			if mode.IsDir() || mode.IsRegular() {
+				return dir, nil
+			}
+		} else if !errors.Is(err, os.ErrNotExist) {
+			return "", fmt.Errorf("checking .git in %s: %w", dir, err)
+		}
+
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			return "", errors.New("not in a git repository")
+		}
+		dir = parent
+	}
+}
+
 // InstallDirForScope returns the skill installation directory for the given
 // scope. An empty scope defaults to "user".
 //
 //   - user (default): ~/.agents/skills  (absolute, under the user's home directory)
-//   - repo:           .agents/skills    (relative to the current working directory;
-//     the caller should ensure it is invoked from the repository root)
+//   - repo:           <repo-root>/.agents/skills  (absolute, under the repository root
+//     found by traversing parent directories for .git)
 func InstallDirForScope(scope string) (string, error) {
 	switch scope {
 	case "", "user":
@@ -21,7 +55,11 @@ func InstallDirForScope(scope string) (string, error) {
 		}
 		return filepath.Join(home, ".agents", "skills"), nil
 	case "repo":
-		return filepath.Join(".agents", "skills"), nil
+		root, err := FindRepoRoot()
+		if err != nil {
+			return "", err
+		}
+		return filepath.Join(root, ".agents", "skills"), nil
 	default:
 		return "", fmt.Errorf("unknown scope %q (supported: user, repo)", scope)
 	}

--- a/resolve.go
+++ b/resolve.go
@@ -7,7 +7,7 @@ import (
 	"path/filepath"
 )
 
-// FindRepoRoot traverses parent directories from the current working directory
+// findRepoRoot traverses parent directories from the current working directory
 // to find the repository root (the directory containing a .git entry).
 //
 // It uses os.Lstat to avoid following symlinks: .git must be a directory

--- a/resolve.go
+++ b/resolve.go
@@ -15,7 +15,7 @@ import (
 // ignored for security.
 //
 // Returns an error if the filesystem root is reached without finding .git.
-func FindRepoRoot() (string, error) {
+func findRepoRoot() (string, error) {
 	dir, err := os.Getwd()
 	if err != nil {
 		return "", fmt.Errorf("getting current directory: %w", err)
@@ -55,7 +55,7 @@ func InstallDirForScope(scope string) (string, error) {
 		}
 		return filepath.Join(home, ".agents", "skills"), nil
 	case "repo":
-		root, err := FindRepoRoot()
+		root, err := findRepoRoot()
 		if err != nil {
 			return "", err
 		}

--- a/resolve.go
+++ b/resolve.go
@@ -57,7 +57,7 @@ func InstallDirForScope(scope string) (string, error) {
 	case "repo":
 		root, err := findRepoRoot()
 		if err != nil {
-			return "", err
+			return "", fmt.Errorf("resolving install dir for scope %q (finding repo root): %w", scope, err)
 		}
 		return filepath.Join(root, ".agents", "skills"), nil
 	default:

--- a/resolve.go
+++ b/resolve.go
@@ -7,18 +7,18 @@ import (
 	"path/filepath"
 )
 
-// findRepoRoot traverses parent directories from the current working directory
+// findRepoRoot traverses parent directories starting from startDir
 // to find the repository root (the directory containing a .git entry).
 //
 // It uses os.Lstat to avoid following symlinks: .git must be a directory
 // (normal repo) or a regular file (git worktree). A symlink named .git is
-// ignored for security.
+// treated as a hard error for security.
 //
 // Returns an error if the filesystem root is reached without finding .git.
-func findRepoRoot() (string, error) {
-	dir, err := os.Getwd()
+func findRepoRoot(startDir string) (string, error) {
+	dir, err := filepath.Abs(startDir)
 	if err != nil {
-		return "", fmt.Errorf("getting current directory: %w", err)
+		return "", fmt.Errorf("resolving absolute path for %q: %w", startDir, err)
 	}
 
 	for {
@@ -61,7 +61,11 @@ func InstallDirForScope(scope string) (string, error) {
 		}
 		return filepath.Join(home, ".agents", "skills"), nil
 	case "repo":
-		root, err := findRepoRoot()
+		wd, err := os.Getwd()
+		if err != nil {
+			return "", fmt.Errorf("resolving install dir for scope %q: %w", scope, err)
+		}
+		root, err := findRepoRoot(wd)
 		if err != nil {
 			return "", fmt.Errorf("resolving install dir for scope %q (finding repo root): %w", scope, err)
 		}

--- a/resolve_test.go
+++ b/resolve_test.go
@@ -44,9 +44,9 @@ func TestInstallDirForScope_Repo(t *testing.T) {
 		t.Errorf("InstallDirForScope(\"repo\") = %q, want path ending with .agents/skills", got)
 	}
 
-	root, err := FindRepoRoot()
+	root, err := findRepoRoot()
 	if err != nil {
-		t.Fatalf("FindRepoRoot error: %v", err)
+		t.Fatalf("findRepoRoot error: %v", err)
 	}
 	want := filepath.Join(root, ".agents", "skills")
 	if got != want {
@@ -62,12 +62,12 @@ func TestInstallDirForScope_UnknownScope(t *testing.T) {
 }
 
 func TestFindRepoRoot_FromRepoDir(t *testing.T) {
-	root, err := FindRepoRoot()
+	root, err := findRepoRoot()
 	if err != nil {
-		t.Fatalf("FindRepoRoot() error: %v", err)
+		t.Fatalf("findRepoRoot() error: %v", err)
 	}
 	if !filepath.IsAbs(root) {
-		t.Errorf("FindRepoRoot() = %q, want absolute path", root)
+		t.Errorf("findRepoRoot() = %q, want absolute path", root)
 	}
 	fi, err := os.Lstat(filepath.Join(root, ".git"))
 	if err != nil {
@@ -95,20 +95,20 @@ func TestFindRepoRoot_FromSubdir(t *testing.T) {
 		t.Skipf("cannot chdir to agentskill subdir: %v", err)
 	}
 
-	root, err := FindRepoRoot()
+	root, err := findRepoRoot()
 	if err != nil {
-		t.Fatalf("FindRepoRoot() from subdir error: %v", err)
+		t.Fatalf("findRepoRoot() from subdir error: %v", err)
 	}
 
 	// The root found from subdir should match the root found from the original dir.
 	if err := os.Chdir(orig); err != nil {
 		t.Fatal(err)
 	}
-	expected, err := FindRepoRoot()
+	expected, err := findRepoRoot()
 	if err != nil {
 		t.Fatal(err)
 	}
 	if root != expected {
-		t.Errorf("FindRepoRoot() from subdir = %q, want %q", root, expected)
+		t.Errorf("findRepoRoot() from subdir = %q, want %q", root, expected)
 	}
 }

--- a/resolve_test.go
+++ b/resolve_test.go
@@ -42,15 +42,38 @@ func TestInstallDirForScope(t *testing.T) {
 	}
 
 	t.Run("repo scope returns absolute path under repo root", func(t *testing.T) {
+		// Create a fake repo and chdir into a nested directory under it so the test
+		// does not depend on the real working directory containing a .git entry.
+		fakeRoot := setupFakeRepo(t, false)
+
+		nestedDir := filepath.Join(fakeRoot, "sub", "dir")
+		if err := os.MkdirAll(nestedDir, 0o755); err != nil {
+			t.Fatalf("failed to create nested directory: %v", err)
+		}
+
+		origWD, err := os.Getwd()
+		if err != nil {
+			t.Fatalf("failed to get working directory: %v", err)
+		}
+
+		if err := os.Chdir(nestedDir); err != nil {
+			t.Fatalf("failed to chdir to nested directory: %v", err)
+		}
+
+		t.Cleanup(func() {
+			if err := os.Chdir(origWD); err != nil {
+				t.Fatalf("failed to restore working directory: %v", err)
+			}
+		})
+
 		got, err := InstallDirForScope("repo")
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
-		if !filepath.IsAbs(got) {
-			t.Errorf("got %q, want absolute path", got)
-		}
-		if !strings.HasSuffix(got, filepath.Join(".agents", "skills")) {
-			t.Errorf("got %q, want path ending with .agents/skills", got)
+
+		want := filepath.Join(fakeRoot, ".agents", "skills")
+		if got != want {
+			t.Errorf("got %q, want %q", got, want)
 		}
 	})
 }

--- a/resolve_test.go
+++ b/resolve_test.go
@@ -62,7 +62,7 @@ func TestInstallDirForScope(t *testing.T) {
 
 		t.Cleanup(func() {
 			if err := os.Chdir(origWD); err != nil {
-				t.Fatalf("failed to restore working directory: %v", err)
+				t.Errorf("failed to restore working directory: %v", err)
 			}
 		})
 

--- a/resolve_test.go
+++ b/resolve_test.go
@@ -3,6 +3,7 @@ package skillsmith
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -36,7 +37,18 @@ func TestInstallDirForScope_Repo(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	want := filepath.Join(".agents", "skills")
+	if !filepath.IsAbs(got) {
+		t.Errorf("InstallDirForScope(\"repo\") = %q, want absolute path", got)
+	}
+	if !strings.HasSuffix(got, filepath.Join(".agents", "skills")) {
+		t.Errorf("InstallDirForScope(\"repo\") = %q, want path ending with .agents/skills", got)
+	}
+
+	root, err := FindRepoRoot()
+	if err != nil {
+		t.Fatalf("FindRepoRoot error: %v", err)
+	}
+	want := filepath.Join(root, ".agents", "skills")
 	if got != want {
 		t.Errorf("InstallDirForScope(\"repo\") = %q, want %q", got, want)
 	}
@@ -46,5 +58,57 @@ func TestInstallDirForScope_UnknownScope(t *testing.T) {
 	_, err := InstallDirForScope("unknown")
 	if err == nil {
 		t.Error("expected error for unknown scope, got nil")
+	}
+}
+
+func TestFindRepoRoot_FromRepoDir(t *testing.T) {
+	root, err := FindRepoRoot()
+	if err != nil {
+		t.Fatalf("FindRepoRoot() error: %v", err)
+	}
+	if !filepath.IsAbs(root) {
+		t.Errorf("FindRepoRoot() = %q, want absolute path", root)
+	}
+	fi, err := os.Lstat(filepath.Join(root, ".git"))
+	if err != nil {
+		t.Fatalf("no .git at reported root %q: %v", root, err)
+	}
+	if !fi.IsDir() && !fi.Mode().IsRegular() {
+		t.Errorf(".git at %q is neither a directory nor a regular file", root)
+	}
+}
+
+func TestFindRepoRoot_FromSubdir(t *testing.T) {
+	// Change to a subdirectory of the repo and verify we still find the root.
+	orig, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		if err := os.Chdir(orig); err != nil {
+			t.Errorf("restoring working directory: %v", err)
+		}
+	})
+
+	subdir := filepath.Join(orig, "agentskill")
+	if err := os.Chdir(subdir); err != nil {
+		t.Skipf("cannot chdir to agentskill subdir: %v", err)
+	}
+
+	root, err := FindRepoRoot()
+	if err != nil {
+		t.Fatalf("FindRepoRoot() from subdir error: %v", err)
+	}
+
+	// The root found from subdir should match the root found from the original dir.
+	if err := os.Chdir(orig); err != nil {
+		t.Fatal(err)
+	}
+	expected, err := FindRepoRoot()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if root != expected {
+		t.Errorf("FindRepoRoot() from subdir = %q, want %q", root, expected)
 	}
 }

--- a/resolve_test.go
+++ b/resolve_test.go
@@ -84,6 +84,12 @@ func TestInstallDirForScope(t *testing.T) {
 func setupFakeRepo(t *testing.T, gitFile bool) string {
 	t.Helper()
 	root := t.TempDir()
+	// Resolve symlinks so tests match os.Getwd() on macOS where
+	// /var is a symlink to /private/var.
+	root, err := filepath.EvalSymlinks(root)
+	if err != nil {
+		t.Fatal(err)
+	}
 	gitPath := filepath.Join(root, ".git")
 	if gitFile {
 		if err := os.WriteFile(gitPath, []byte("gitdir: /some/other/path\n"), 0o644); err != nil {

--- a/resolve_test.go
+++ b/resolve_test.go
@@ -8,38 +8,40 @@ import (
 )
 
 func TestInstallDirForScope(t *testing.T) {
-	home, err := os.UserHomeDir()
-	if err != nil {
-		t.Skip("cannot determine home directory:", err)
-	}
+	t.Run("user scope", func(t *testing.T) {
+		home, err := os.UserHomeDir()
+		if err != nil {
+			t.Skip("cannot determine home directory:", err)
+		}
 
-	tests := []struct {
-		name    string
-		scope   string
-		want    string
-		wantErr bool
-	}{
-		{name: "empty defaults to user", scope: "", want: filepath.Join(home, ".agents", "skills")},
-		{name: "explicit user", scope: "user", want: filepath.Join(home, ".agents", "skills")},
-		{name: "unknown scope", scope: "unknown", wantErr: true},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got, err := InstallDirForScope(tt.scope)
-			if tt.wantErr {
-				if err == nil {
-					t.Fatal("expected error, got nil")
+		tests := []struct {
+			name    string
+			scope   string
+			want    string
+			wantErr bool
+		}{
+			{name: "empty defaults to user", scope: "", want: filepath.Join(home, ".agents", "skills")},
+			{name: "explicit user", scope: "user", want: filepath.Join(home, ".agents", "skills")},
+			{name: "unknown scope", scope: "unknown", wantErr: true},
+		}
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				got, err := InstallDirForScope(tt.scope)
+				if tt.wantErr {
+					if err == nil {
+						t.Fatal("expected error, got nil")
+					}
+					return
 				}
-				return
-			}
-			if err != nil {
-				t.Fatalf("unexpected error: %v", err)
-			}
-			if got != tt.want {
-				t.Errorf("got %q, want %q", got, tt.want)
-			}
-		})
-	}
+				if err != nil {
+					t.Fatalf("unexpected error: %v", err)
+				}
+				if got != tt.want {
+					t.Errorf("got %q, want %q", got, tt.want)
+				}
+			})
+		}
+	})
 
 	t.Run("repo scope returns absolute path under repo root", func(t *testing.T) {
 		// Create a fake repo and chdir into a nested directory under it so the test

--- a/resolve_test.go
+++ b/resolve_test.go
@@ -7,108 +7,129 @@ import (
 	"testing"
 )
 
-func TestInstallDirForScope_User(t *testing.T) {
+func TestInstallDirForScope(t *testing.T) {
 	home, err := os.UserHomeDir()
 	if err != nil {
 		t.Skip("cannot determine home directory:", err)
 	}
 
 	tests := []struct {
-		scope string
-		want  string
+		name    string
+		scope   string
+		want    string
+		wantErr bool
 	}{
-		{"", filepath.Join(home, ".agents", "skills")},
-		{"user", filepath.Join(home, ".agents", "skills")},
+		{name: "empty defaults to user", scope: "", want: filepath.Join(home, ".agents", "skills")},
+		{name: "explicit user", scope: "user", want: filepath.Join(home, ".agents", "skills")},
+		{name: "unknown scope", scope: "unknown", wantErr: true},
 	}
 	for _, tt := range tests {
-		got, err := InstallDirForScope(tt.scope)
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := InstallDirForScope(tt.scope)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatal("expected error, got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got != tt.want {
+				t.Errorf("got %q, want %q", got, tt.want)
+			}
+		})
+	}
+
+	t.Run("repo scope returns absolute path under repo root", func(t *testing.T) {
+		got, err := InstallDirForScope("repo")
 		if err != nil {
-			t.Errorf("InstallDirForScope(%q) error: %v", tt.scope, err)
-			continue
+			t.Fatalf("unexpected error: %v", err)
 		}
-		if got != tt.want {
-			t.Errorf("InstallDirForScope(%q) = %q, want %q", tt.scope, got, tt.want)
+		if !filepath.IsAbs(got) {
+			t.Errorf("got %q, want absolute path", got)
+		}
+		if !strings.HasSuffix(got, filepath.Join(".agents", "skills")) {
+			t.Errorf("got %q, want path ending with .agents/skills", got)
+		}
+	})
+}
+
+// setupFakeRepo creates a temporary directory containing a .git entry
+// and returns the path. If gitFile is true, .git is created as a regular
+// file (simulating a worktree); otherwise it is created as a directory.
+func setupFakeRepo(t *testing.T, gitFile bool) string {
+	t.Helper()
+	root := t.TempDir()
+	gitPath := filepath.Join(root, ".git")
+	if gitFile {
+		if err := os.WriteFile(gitPath, []byte("gitdir: /some/other/path\n"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	} else {
+		if err := os.Mkdir(gitPath, 0o755); err != nil {
+			t.Fatal(err)
 		}
 	}
+	return root
 }
 
-func TestInstallDirForScope_Repo(t *testing.T) {
-	got, err := InstallDirForScope("repo")
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
+func TestFindRepoRoot(t *testing.T) {
+	tests := []struct {
+		name    string
+		gitFile bool // true = .git file (worktree), false = .git directory
+		subdir  string
+	}{
+		{name: "root with .git dir", gitFile: false},
+		{name: "root with .git file (worktree)", gitFile: true},
+		{name: "subdir with .git dir", gitFile: false, subdir: "a/b/c"},
+		{name: "subdir with .git file (worktree)", gitFile: true, subdir: "deep/nested"},
 	}
-	if !filepath.IsAbs(got) {
-		t.Errorf("InstallDirForScope(\"repo\") = %q, want absolute path", got)
-	}
-	if !strings.HasSuffix(got, filepath.Join(".agents", "skills")) {
-		t.Errorf("InstallDirForScope(\"repo\") = %q, want path ending with .agents/skills", got)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			root := setupFakeRepo(t, tt.gitFile)
+
+			startDir := root
+			if tt.subdir != "" {
+				startDir = filepath.Join(root, tt.subdir)
+				if err := os.MkdirAll(startDir, 0o755); err != nil {
+					t.Fatal(err)
+				}
+			}
+
+			got, err := findRepoRoot(startDir)
+			if err != nil {
+				t.Fatalf("findRepoRoot(%q) error: %v", startDir, err)
+			}
+			if got != root {
+				t.Errorf("findRepoRoot(%q) = %q, want %q", startDir, got, root)
+			}
+		})
 	}
 
-	root, err := findRepoRoot()
-	if err != nil {
-		t.Fatalf("findRepoRoot error: %v", err)
-	}
-	want := filepath.Join(root, ".agents", "skills")
-	if got != want {
-		t.Errorf("InstallDirForScope(\"repo\") = %q, want %q", got, want)
-	}
-}
-
-func TestInstallDirForScope_UnknownScope(t *testing.T) {
-	_, err := InstallDirForScope("unknown")
-	if err == nil {
-		t.Error("expected error for unknown scope, got nil")
-	}
-}
-
-func TestFindRepoRoot_FromRepoDir(t *testing.T) {
-	root, err := findRepoRoot()
-	if err != nil {
-		t.Fatalf("findRepoRoot() error: %v", err)
-	}
-	if !filepath.IsAbs(root) {
-		t.Errorf("findRepoRoot() = %q, want absolute path", root)
-	}
-	fi, err := os.Lstat(filepath.Join(root, ".git"))
-	if err != nil {
-		t.Fatalf("no .git at reported root %q: %v", root, err)
-	}
-	if !fi.IsDir() && !fi.Mode().IsRegular() {
-		t.Errorf(".git at %q is neither a directory nor a regular file", root)
-	}
-}
-
-func TestFindRepoRoot_FromSubdir(t *testing.T) {
-	// Change to a subdirectory of the repo and verify we still find the root.
-	orig, err := os.Getwd()
-	if err != nil {
-		t.Fatal(err)
-	}
-	t.Cleanup(func() {
-		if err := os.Chdir(orig); err != nil {
-			t.Errorf("restoring working directory: %v", err)
+	t.Run("not in a git repository", func(t *testing.T) {
+		dir := t.TempDir() // no .git
+		_, err := findRepoRoot(dir)
+		if err == nil {
+			t.Fatal("expected error, got nil")
+		}
+		if !strings.Contains(err.Error(), "not in a git repository") {
+			t.Errorf("error = %q, want it to contain %q", err.Error(), "not in a git repository")
 		}
 	})
 
-	subdir := filepath.Join(orig, "agentskill")
-	if err := os.Chdir(subdir); err != nil {
-		t.Skipf("cannot chdir to agentskill subdir: %v", err)
-	}
-
-	root, err := findRepoRoot()
-	if err != nil {
-		t.Fatalf("findRepoRoot() from subdir error: %v", err)
-	}
-
-	// The root found from subdir should match the root found from the original dir.
-	if err := os.Chdir(orig); err != nil {
-		t.Fatal(err)
-	}
-	expected, err := findRepoRoot()
-	if err != nil {
-		t.Fatal(err)
-	}
-	if root != expected {
-		t.Errorf("findRepoRoot() from subdir = %q, want %q", root, expected)
-	}
+	t.Run("symlink .git is rejected", func(t *testing.T) {
+		root := t.TempDir()
+		target := t.TempDir()
+		if err := os.Symlink(target, filepath.Join(root, ".git")); err != nil {
+			t.Skip("cannot create symlink:", err)
+		}
+		_, err := findRepoRoot(root)
+		if err == nil {
+			t.Fatal("expected error for symlink .git, got nil")
+		}
+		if !strings.Contains(err.Error(), "symlink") {
+			t.Errorf("error = %q, want it to mention symlink", err.Error())
+		}
+	})
 }

--- a/smith.go
+++ b/smith.go
@@ -101,7 +101,7 @@ type commonFlags struct {
 func addCommonFlags(f *flag.FlagSet, cf *commonFlags) {
 	f.BoolVar(&cf.dryRun, "dry-run", false, "print what would happen without making changes")
 	f.StringVar(&cf.prefix, "prefix", "", "skill installation directory (overrides --scope)")
-	f.StringVar(&cf.scope, "scope", "", "target scope: user (~/.agents/skills, default) or repo (.agents/skills)")
+	f.StringVar(&cf.scope, "scope", "", "target scope: user (~/.agents/skills, default) or repo (<repo-root>/.agents/skills)")
 	f.BoolVar(&cf.force, "force", false, "overwrite unmanaged skills")
 }
 


### PR DESCRIPTION
## Problem

When `--scope repo` is used, `InstallDirForScope` returned a relative path `.agents/skills`. This means skills are installed relative to the current working directory, which is wrong if the user is in a subdirectory of the repo.

## Solution

Added `findRepoRoot(startDir string)` to `resolve.go` that traverses parent directories from a given starting directory to find the repository root (the directory containing `.git`). `InstallDirForScope("repo")` now gets the current working directory and passes it to `findRepoRoot()`, returning an absolute `<repo-root>/.agents/skills` path.

Security: uses `os.Lstat` to prevent symlink attacks, accepts `.git` as a directory (normal repo) or regular file (git worktree) but rejects symlinks with a hard error, errors at filesystem root with `"not in a git repository"`.

The function accepts a starting directory argument (rather than calling `os.Getwd` internally) for better testability.

## Changes

- **`resolve.go`**: Added `findRepoRoot(startDir string)` function (unexported, accepts a directory parameter); updated `InstallDirForScope("repo")` to return an absolute path under the detected repo root.
- **`resolve_test.go`**: Table-driven tests with a `setupFakeRepo` helper using `t.TempDir()` for hermetic tests covering `.git` directory, `.git` file (worktree), subdirectory traversal, not-in-repo error, and symlink rejection.
- **`smith.go`**: Updated the `--scope` flag help string to say `<repo-root>/.agents/skills` instead of the old relative `.agents/skills`, matching the actual behavior.
- **`SKETCH.md`**: Updated the options table and resolution priority section to describe auto-detection of the repository root.

<!-- START COPILOT CODING AGENT TIPS -->
---

💡 You can make Copilot smarter by setting up custom instructions, customizing its development environment and configuring Model Context Protocol (MCP) servers. Learn more [Copilot coding agent tips](https://gh.io/copilot-coding-agent-tips) in the docs.