### PR TITLE
Add New constructor, make fields private

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,11 +21,9 @@ var skillsFS embed.FS
 
 func run(ctx context.Context, args []string) error {
     if len(args) > 0 && args[0] == "skills" {
-        sub, _ := fs.Sub(skillsFS, "skills")
-        s := &skillsmith.Smith{
-            FS:      sub,
-            Version: version,
-            Name:    "mytool",
+        s, err := skillsmith.New("mytool", version, skillsFS)
+        if err != nil {
+            log.Fatal(err)
         }
         return s.Run(ctx, args[1:])
     }

--- a/SKETCH.md
+++ b/SKETCH.md
@@ -81,10 +81,9 @@ func main() {
 
 func run(ctx context.Context, args []string) error {
     if len(args) > 0 && args[0] == "skills" {
-        s := &skillsmith.Smith{
-            FS:      skillsFS,
-            Version: version,
-            Name:    "mytool",
+        s, err := skillsmith.New("mytool", version, skillsFS)
+        if err != nil {
+            log.Fatal(err)
         }
         return s.Run(ctx, args[1:])
     }

--- a/cmd/skillsmith/main.go
+++ b/cmd/skillsmith/main.go
@@ -14,12 +14,11 @@ func main() {
 
 	args := os.Args[1:]
 	if len(args) > 0 && args[0] == "skills" {
-		s := &skillsmith.Smith{
-			FS:      skillsmith.DemoFS(),
-			Version: skillsmith.Version(),
-			Name:    "skillsmith",
+		s, err := skillsmith.New("skillsmith", skillsmith.Version(), skillsmith.DemoFS())
+		if err != nil {
+			log.Fatal(err)
 		}
-		err := s.Run(context.Background(), args[1:])
+		err = s.Run(context.Background(), args[1:])
 		if err != nil && err != flag.ErrHelp {
 			log.Println(err)
 			os.Exit(1)

--- a/cmd_install.go
+++ b/cmd_install.go
@@ -25,12 +25,12 @@ func (s *Smith) cmdInstall(_ context.Context, args []string, out, errW io.Writer
 		return err
 	}
 
-	result, err := CopySkills(s.skillsFS(), dir, CopyOptions{
+	result, err := CopySkills(s.fs, dir, CopyOptions{
 		Mode:    ModeInstall,
 		Force:   cf.force,
 		DryRun:  cf.dryRun,
-		Name:    s.Name,
-		Version: s.Version,
+		Name:    s.name,
+		Version: s.version,
 	})
 	if err != nil {
 		return err

--- a/cmd_list.go
+++ b/cmd_list.go
@@ -20,7 +20,7 @@ func (s *Smith) cmdList(_ context.Context, args []string, out, errW io.Writer) e
 		return err
 	}
 
-	skills, discoverErr := agentskill.Discover(s.skillsFS())
+	skills, discoverErr := agentskill.Discover(s.fs)
 	var fatalErr error
 	eachError(discoverErr, func(e error) {
 		var se *agentskill.SkillError

--- a/cmd_reinstall.go
+++ b/cmd_reinstall.go
@@ -25,12 +25,12 @@ func (s *Smith) cmdReinstall(_ context.Context, args []string, out, errW io.Writ
 		return err
 	}
 
-	result, err := CopySkills(s.skillsFS(), dir, CopyOptions{
+	result, err := CopySkills(s.fs, dir, CopyOptions{
 		Mode:    ModeReinstall,
 		Force:   cf.force,
 		DryRun:  cf.dryRun,
-		Name:    s.Name,
-		Version: s.Version,
+		Name:    s.name,
+		Version: s.version,
 	})
 	if err != nil {
 		return err

--- a/cmd_status.go
+++ b/cmd_status.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"path/filepath"
+	"strings"
 
 	"github.com/Songmu/skillsmith/agentskill"
 )
@@ -57,7 +58,7 @@ func (s *Smith) cmdStatus(_ context.Context, args []string, out, errW io.Writer)
 			continue
 		}
 
-		if meta.Version == s.version {
+		if strings.TrimPrefix(meta.Version, "v") == strings.TrimPrefix(s.version, "v") {
 			fmt.Fprintf(out, "%-30s installed %s (up to date)\n", skill.Dir, meta.Version)
 		} else {
 			fmt.Fprintf(out, "%-30s installed %s → available %s\n", skill.Dir, meta.Version, s.version)

--- a/cmd_status.go
+++ b/cmd_status.go
@@ -28,7 +28,7 @@ func (s *Smith) cmdStatus(_ context.Context, args []string, out, errW io.Writer)
 		return err
 	}
 
-	skills, discoverErr := agentskill.Discover(s.skillsFS())
+	skills, discoverErr := agentskill.Discover(s.fs)
 	var fatalErr error
 	eachError(discoverErr, func(e error) {
 		var se *agentskill.SkillError
@@ -57,10 +57,10 @@ func (s *Smith) cmdStatus(_ context.Context, args []string, out, errW io.Writer)
 			continue
 		}
 
-		if meta.Version == s.Version {
+		if meta.Version == s.version {
 			fmt.Fprintf(out, "%-30s installed %s (up to date)\n", skill.Dir, meta.Version)
 		} else {
-			fmt.Fprintf(out, "%-30s installed %s → available %s\n", skill.Dir, meta.Version, s.Version)
+			fmt.Fprintf(out, "%-30s installed %s → available %s\n", skill.Dir, meta.Version, s.version)
 		}
 	}
 	return nil

--- a/cmd_uninstall.go
+++ b/cmd_uninstall.go
@@ -29,7 +29,7 @@ func (s *Smith) cmdUninstall(_ context.Context, args []string, out, errW io.Writ
 		return err
 	}
 
-	skills, discoverErr := agentskill.Discover(s.skillsFS())
+	skills, discoverErr := agentskill.Discover(s.fs)
 	if discoverErr != nil {
 		var skillErr *agentskill.SkillError
 		if !errors.As(discoverErr, &skillErr) {

--- a/cmd_update.go
+++ b/cmd_update.go
@@ -25,12 +25,12 @@ func (s *Smith) cmdUpdate(_ context.Context, args []string, out, errW io.Writer)
 		return err
 	}
 
-	result, err := CopySkills(s.skillsFS(), dir, CopyOptions{
+	result, err := CopySkills(s.fs, dir, CopyOptions{
 		Mode:    ModeUpdate,
 		Force:   cf.force,
 		DryRun:  cf.dryRun,
-		Name:    s.Name,
-		Version: s.Version,
+		Name:    s.name,
+		Version: s.version,
 	})
 	if err != nil {
 		return err

--- a/copy.go
+++ b/copy.go
@@ -9,6 +9,7 @@ import (
 	"encoding/hex"
 	"os"
 	"path/filepath"
+	"strings"
 	"time"
 
 	"github.com/Songmu/skillsmith/agentskill"
@@ -166,7 +167,7 @@ func copySkill(src fs.FS, destDir string, skill *agentskill.Skill, opts CopyOpti
 			return "skipped", fmt.Sprintf("skill %q is not managed by skillsmith", skill.Dir), nil
 		}
 		meta, readErr := ReadMeta(dest)
-		if readErr == nil && meta.Version == opts.Version {
+		if readErr == nil && strings.TrimPrefix(meta.Version, "v") == strings.TrimPrefix(opts.Version, "v") {
 			// Same version — nothing to do.
 			return "skipped", fmt.Sprintf("skill %q is already at version %q", skill.Dir, opts.Version), nil
 		}

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,6 @@ module github.com/Songmu/skillsmith
 go 1.26.1
 
 require (
-    github.com/goccy/go-yaml v1.19.2
-    golang.org/x/mod v0.34.0
+	github.com/goccy/go-yaml v1.19.2
+	golang.org/x/mod v0.34.0
 )

--- a/go.mod
+++ b/go.mod
@@ -3,3 +3,5 @@ module github.com/Songmu/skillsmith
 go 1.26.1
 
 require github.com/goccy/go-yaml v1.19.2
+
+require golang.org/x/mod v0.34.0

--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,7 @@ module github.com/Songmu/skillsmith
 
 go 1.26.1
 
-require github.com/goccy/go-yaml v1.19.2
-
-require golang.org/x/mod v0.34.0
+require (
+    github.com/goccy/go-yaml v1.19.2
+    golang.org/x/mod v0.34.0
+)

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,4 @@
 github.com/goccy/go-yaml v1.19.2 h1:PmFC1S6h8ljIz6gMRBopkjP1TVT7xuwrButHID66PoM=
 github.com/goccy/go-yaml v1.19.2/go.mod h1:XBurs7gK8ATbW4ZPGKgcbrY1Br56PdM69F7LkFRi1kA=
+golang.org/x/mod v0.34.0 h1:xIHgNUUnW6sYkcM5Jleh05DvLOtwc6RitGHbDk4akRI=
+golang.org/x/mod v0.34.0/go.mod h1:ykgH52iCZe79kzLLMhyCUzhMci+nQj+0XkbXpNYtVjY=

--- a/smith.go
+++ b/smith.go
@@ -8,62 +8,78 @@ import (
 	"io"
 	"io/fs"
 	"os"
-	"sync"
+	"strings"
+
+	"golang.org/x/mod/semver"
 )
 
 // Smith is the main entry point for the skillsmith skills subcommand.
-// Embed an fs.FS containing skill directories and call Run to dispatch
-// to the appropriate subcommand.
+// Create one with New and call Run to dispatch to the appropriate subcommand.
 type Smith struct {
-	// FS holds the embedded or in-memory skill files.
-	FS fs.FS
-	// Version is the version string of the hosting CLI tool.
-	Version string
-	// Name is the name of the hosting CLI tool (written to .skillsmith.json).
-	Name string
+	// FlagSet is the top-level flag set, created by New.
+	FlagSet *flag.FlagSet
 	// OutWriter is the writer for normal output (defaults to os.Stdout).
 	OutWriter io.Writer
 	// ErrWriter is the writer for error / diagnostic output (defaults to os.Stderr).
 	ErrWriter io.Writer
 
-	skillsFSOnce sync.Once
-	skillsFSVal  fs.FS
+	name    string // name of the hosting CLI tool
+	version string // version without "v" prefix
+	fs      fs.FS  // auto-detected skills FS
 }
 
-// skillsFS returns the effective skills FS. If the root of s.FS contains a
-// directory named "skills" (and no other directories), it is treated as an
-// embed container prefix and stripped via fs.Sub. Files at root are ignored
-// for this check. Otherwise s.FS is used as-is.
-// The result is cached after the first call.
-func (s *Smith) skillsFS() fs.FS {
-	s.skillsFSOnce.Do(func() {
-		entries, err := fs.ReadDir(s.FS, ".")
-		if err != nil {
-			s.skillsFSVal = s.FS
-			return
-		}
+// New creates a Smith with the given name, version and skill filesystem.
+//
+// Version validation: if version does not start with "v", one is prepended
+// for validation only. The version is stored without the "v" prefix.
+//
+// FS auto-detection: if the root of skillFS contains exactly one directory
+// named "skills" (files at root are ignored), that directory is used as the
+// skill root via fs.Sub. Otherwise skillFS is used as-is.
+func New(name, version string, skillFS fs.FS) (*Smith, error) {
+	// Validate version using semver (requires "v" prefix).
+	vv := version
+	if !strings.HasPrefix(vv, "v") {
+		vv = "v" + vv
+	}
+	if !semver.IsValid(vv) {
+		return nil, fmt.Errorf("invalid version %q", version)
+	}
+	// Store without "v" prefix.
+	stored := strings.TrimPrefix(vv, "v")
+
+	// FS auto-detection: strip "skills/" prefix when it is the only directory.
+	detectedFS := skillFS
+	entries, err := fs.ReadDir(skillFS, ".")
+	if err == nil {
 		var dirs []string
 		for _, e := range entries {
 			if e.IsDir() {
 				dirs = append(dirs, e.Name())
 			}
-			// Files at root are ignored: e.g. README.md alongside skills/.
+			// Files at root are intentionally ignored.
 		}
-		// Only strip when there is exactly one directory and it is named "skills".
-		// Any other name indicates the directory is itself a skill, not a container.
-		if len(dirs) != 1 || dirs[0] != "skills" {
-			s.skillsFSVal = s.FS
-			return
+		if len(dirs) == 1 && dirs[0] == "skills" {
+			if sub, subErr := fs.Sub(skillFS, "skills"); subErr == nil {
+				detectedFS = sub
+			}
 		}
-		sub, err := fs.Sub(s.FS, "skills")
-		if err != nil {
-			s.skillsFSVal = s.FS
-			return
-		}
-		s.skillsFSVal = sub
-	})
-	return s.skillsFSVal
+	}
+
+	s := &Smith{
+		name:    name,
+		version: stored,
+		fs:      detectedFS,
+		FlagSet: flag.NewFlagSet(name+" skills", flag.ContinueOnError),
+	}
+	return s, nil
 }
+
+// Name returns the name of the hosting CLI tool.
+func (s *Smith) Name() string { return s.name }
+
+// Version returns the version string (without the "v" prefix).
+func (s *Smith) Version() string { return s.version }
 
 // subcommands lists the available subcommands and their one-line descriptions.
 var subcommands = []struct{ name, desc string }{
@@ -80,15 +96,15 @@ func (s *Smith) Run(ctx context.Context, args []string) error {
 	out := s.outWriter()
 	errW := s.errWriter()
 
-	top := flag.NewFlagSet("skills", flag.ContinueOnError)
+	top := s.FlagSet
 	top.SetOutput(errW)
 	top.Usage = func() {
-		fmt.Fprintf(errW, "Usage: skills <command> [options]\n\n")
+		fmt.Fprintf(errW, "Usage: %s <command> [options]\n\n", top.Name())
 		fmt.Fprintf(errW, "Commands:\n")
 		for _, cmd := range subcommands {
 			fmt.Fprintf(errW, "  %-12s %s\n", cmd.name, cmd.desc)
 		}
-		fmt.Fprintf(errW, "\nRun 'skills <command> --help' for command-specific options.\n")
+		fmt.Fprintf(errW, "\nRun '%s <command> --help' for command-specific options.\n", top.Name())
 	}
 
 	// Parse only the subcommand name; let subcommand parsers handle the rest.

--- a/smith.go
+++ b/smith.go
@@ -24,19 +24,23 @@ type Smith struct {
 	ErrWriter io.Writer
 
 	name    string // name of the hosting CLI tool
-	version string // version without "v" prefix
+	version string // version stored as provided by the caller
 	fs      fs.FS  // auto-detected skills FS
 }
 
 // New creates a Smith with the given name, version and skill filesystem.
 //
 // Version validation: if version does not start with "v", one is prepended
-// for validation only. The version is stored without the "v" prefix.
+// for validation only. The version is stored as provided.
 //
 // FS auto-detection: if the root of skillFS contains exactly one directory
 // named "skills" (files at root are ignored), that directory is used as the
 // skill root via fs.Sub. Otherwise skillFS is used as-is.
 func New(name, version string, skillFS fs.FS) (*Smith, error) {
+	if skillFS == nil {
+		return nil, errors.New("skill filesystem cannot be nil")
+	}
+
 	// Validate version using semver (requires "v" prefix).
 	vv := version
 	if !strings.HasPrefix(vv, "v") {
@@ -44,12 +48,6 @@ func New(name, version string, skillFS fs.FS) (*Smith, error) {
 	}
 	if !semver.IsValid(vv) {
 		return nil, fmt.Errorf("invalid version %q", version)
-	}
-	// Store without "v" prefix.
-	stored := strings.TrimPrefix(vv, "v")
-
-	if skillFS == nil {
-		return nil, errors.New("skill filesystem cannot be nil")
 	}
 
 	// FS auto-detection: strip "skills/" prefix when it is the only directory.
@@ -72,9 +70,18 @@ func New(name, version string, skillFS fs.FS) (*Smith, error) {
 
 	s := &Smith{
 		name:    name,
-		version: stored,
+		version: version,
 		fs:      detectedFS,
 		FlagSet: flag.NewFlagSet(name+" skills", flag.ContinueOnError),
+	}
+	s.FlagSet.Usage = func() {
+		errW := s.errWriter()
+		fmt.Fprintf(errW, "Usage: %s <command> [options]\n\n", s.FlagSet.Name())
+		fmt.Fprintf(errW, "Commands:\n")
+		for _, cmd := range subcommands {
+			fmt.Fprintf(errW, "  %-12s %s\n", cmd.name, cmd.desc)
+		}
+		fmt.Fprintf(errW, "\nRun '%s <command> --help' for command-specific options.\n", s.FlagSet.Name())
 	}
 	return s, nil
 }
@@ -82,7 +89,7 @@ func New(name, version string, skillFS fs.FS) (*Smith, error) {
 // Name returns the name of the hosting CLI tool.
 func (s *Smith) Name() string { return s.name }
 
-// Version returns the version string (without the "v" prefix).
+// Version returns the version string as provided to New.
 func (s *Smith) Version() string { return s.version }
 
 // subcommands lists the available subcommands and their one-line descriptions.
@@ -102,14 +109,6 @@ func (s *Smith) Run(ctx context.Context, args []string) error {
 
 	top := s.FlagSet
 	top.SetOutput(errW)
-	top.Usage = func() {
-		fmt.Fprintf(errW, "Usage: %s <command> [options]\n\n", top.Name())
-		fmt.Fprintf(errW, "Commands:\n")
-		for _, cmd := range subcommands {
-			fmt.Fprintf(errW, "  %-12s %s\n", cmd.name, cmd.desc)
-		}
-		fmt.Fprintf(errW, "\nRun '%s <command> --help' for command-specific options.\n", top.Name())
-	}
 
 	// Parse only the subcommand name; let subcommand parsers handle the rest.
 	if err := top.Parse(args); err != nil {

--- a/smith.go
+++ b/smith.go
@@ -48,6 +48,10 @@ func New(name, version string, skillFS fs.FS) (*Smith, error) {
 	// Store without "v" prefix.
 	stored := strings.TrimPrefix(vv, "v")
 
+	if skillFS == nil {
+		return nil, errors.New("skill filesystem cannot be nil")
+	}
+
 	// FS auto-detection: strip "skills/" prefix when it is the only directory.
 	detectedFS := skillFS
 	entries, err := fs.ReadDir(skillFS, ".")

--- a/smith_test.go
+++ b/smith_test.go
@@ -67,7 +67,7 @@ func TestNew_ValidVersion_WithoutV(t *testing.T) {
 }
 
 func TestSmith_Run_UnknownSubcommand(t *testing.T) {
-	s, _, _ := newTestSmith(testSkillFS)
+	s, _, _ := newTestSmith(t, testSkillFS)
 	err := s.Run(context.Background(), []string{"unknown"})
 	if err == nil {
 		t.Error("expected error for unknown subcommand, got nil")
@@ -75,7 +75,7 @@ func TestSmith_Run_UnknownSubcommand(t *testing.T) {
 }
 
 func TestSmith_Run_NoArgs(t *testing.T) {
-	s, _, _ := newTestSmith(testSkillFS)
+	s, _, _ := newTestSmith(t, testSkillFS)
 	err := s.Run(context.Background(), []string{})
 	if err != nil {
 		t.Errorf("unexpected error: %v", err)
@@ -83,7 +83,7 @@ func TestSmith_Run_NoArgs(t *testing.T) {
 }
 
 func TestSmith_Run_Help(t *testing.T) {
-	s, _, errW := newTestSmith(testSkillFS)
+	s, _, errW := newTestSmith(t, testSkillFS)
 	err := s.Run(context.Background(), []string{"--help"})
 	if err != nil {
 		t.Errorf("unexpected error: %v", err)
@@ -94,7 +94,7 @@ func TestSmith_Run_Help(t *testing.T) {
 }
 
 func TestSmith_List(t *testing.T) {
-	s, out, _ := newTestSmith(testSkillFS)
+	s, out, _ := newTestSmith(t, testSkillFS)
 	err := s.Run(context.Background(), []string{"list"})
 	if err != nil {
 		t.Fatalf("list: %v", err)
@@ -105,7 +105,7 @@ func TestSmith_List(t *testing.T) {
 }
 
 func TestSmith_Install_DryRun(t *testing.T) {
-	s, out, _ := newTestSmith(testSkillFS)
+	s, out, _ := newTestSmith(t, testSkillFS)
 	dir := t.TempDir()
 	err := s.Run(context.Background(), []string{"install", "--prefix", dir, "--dry-run"})
 	if err != nil {
@@ -117,7 +117,7 @@ func TestSmith_Install_DryRun(t *testing.T) {
 }
 
 func TestSmith_Install_ThenStatus(t *testing.T) {
-	s, out, _ := newTestSmith(testSkillFS)
+	s, out, _ := newTestSmith(t, testSkillFS)
 	dir := t.TempDir()
 
 	// Install.
@@ -139,7 +139,7 @@ func TestSmith_Install_ThenStatus(t *testing.T) {
 }
 
 func TestSmith_Uninstall(t *testing.T) {
-	s, out, _ := newTestSmith(testSkillFS)
+	s, out, _ := newTestSmith(t, testSkillFS)
 	dir := t.TempDir()
 
 	if err := s.Run(context.Background(), []string{"install", "--prefix", dir}); err != nil {
@@ -156,7 +156,7 @@ func TestSmith_Uninstall(t *testing.T) {
 }
 
 func TestSmith_Update_NoChange(t *testing.T) {
-	s, out, _ := newTestSmith(testSkillFS)
+	s, out, _ := newTestSmith(t, testSkillFS)
 	dir := t.TempDir()
 
 	if err := s.Run(context.Background(), []string{"install", "--prefix", dir}); err != nil {
@@ -173,7 +173,7 @@ func TestSmith_Update_NoChange(t *testing.T) {
 }
 
 func TestSmith_Reinstall(t *testing.T) {
-	s, out, _ := newTestSmith(testSkillFS)
+	s, out, _ := newTestSmith(t, testSkillFS)
 	dir := t.TempDir()
 
 	if err := s.Run(context.Background(), []string{"install", "--prefix", dir}); err != nil {

--- a/smith_test.go
+++ b/smith_test.go
@@ -3,10 +3,12 @@ package skillsmith
 import (
 	"bytes"
 	"context"
+	"io/fs"
 	"strings"
 	"testing"
 	"testing/fstest"
-	"io/fs"
+
+	"github.com/Songmu/skillsmith/agentskill"
 )
 
 var testSkillFS = fstest.MapFS{
@@ -47,8 +49,8 @@ func TestNew_ValidVersion_WithV(t *testing.T) {
 	if err != nil {
 		t.Fatalf("New: %v", err)
 	}
-	if s.Version() != "1.2.3" {
-		t.Errorf("expected version %q stored without 'v', got %q", "1.2.3", s.Version())
+	if s.Version() != "v1.2.3" {
+		t.Errorf("expected version stored as-is %q, got %q", "v1.2.3", s.Version())
 	}
 }
 
@@ -243,8 +245,22 @@ func TestNew_AutoDetect_SingleDir(t *testing.T) {
 	if err != nil {
 		t.Fatalf("New: %v", err)
 	}
-	if _, err := fs.Stat(s.fs, "demo-skill/SKILL.md"); err != nil {
-		t.Fatalf("expected 'demo-skill' at root of skill FS after auto-detect strip, stat error: %v", err)
+	skills, discoverErr := agentskill.Discover(s.fs)
+	if discoverErr != nil {
+		t.Fatalf("Discover: %v", discoverErr)
+	}
+	found := false
+	for _, sk := range skills {
+		if sk.Dir == "demo-skill" {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected 'demo-skill' at root of s.fs after auto-detect strip, got: %v", skills)
+	}
+	// Verify "skills" wrapper dir was stripped.
+	if _, statErr := fs.Stat(s.fs, "skills"); statErr == nil {
+		t.Error("'skills' dir should have been stripped from root, but it still exists")
 	}
 }
 
@@ -255,8 +271,18 @@ func TestNew_AutoDetect_PreStripped(t *testing.T) {
 	if err != nil {
 		t.Fatalf("New: %v", err)
 	}
-	if _, err := fs.Stat(s.fs, "demo-skill/SKILL.md"); err != nil {
-		t.Fatalf("expected 'demo-skill' at root of pre-stripped skill FS, stat error: %v", err)
+	skills, discoverErr := agentskill.Discover(s.fs)
+	if discoverErr != nil {
+		t.Fatalf("Discover: %v", discoverErr)
+	}
+	found := false
+	for _, sk := range skills {
+		if sk.Dir == "demo-skill" {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected 'demo-skill' at root of s.fs for pre-stripped FS, got: %v", skills)
 	}
 }
 
@@ -267,8 +293,22 @@ func TestNew_AutoDetect_MixedRoot(t *testing.T) {
 	if err != nil {
 		t.Fatalf("New: %v", err)
 	}
-	if _, err := fs.Stat(s.fs, "demo-skill/SKILL.md"); err != nil {
-		t.Fatalf("expected 'demo-skill' at root of mixed-root skill FS, stat error: %v", err)
+	// FS used as-is: README.md must still be present at root.
+	if _, statErr := fs.Stat(s.fs, "README.md"); statErr != nil {
+		t.Errorf("expected README.md at root of s.fs for mixed-root FS, got: %v", statErr)
+	}
+	skills, discoverErr := agentskill.Discover(s.fs)
+	if discoverErr != nil {
+		t.Fatalf("Discover: %v", discoverErr)
+	}
+	found := false
+	for _, sk := range skills {
+		if sk.Dir == "demo-skill" {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected 'demo-skill' discoverable in s.fs for mixed-root FS, got: %v", skills)
 	}
 }
 
@@ -279,8 +319,22 @@ func TestNew_AutoDetect_SkillsDirWithFileAtRoot(t *testing.T) {
 	if err != nil {
 		t.Fatalf("New: %v", err)
 	}
-	if _, err := fs.Stat(s.fs, "demo-skill/SKILL.md"); err != nil {
-		t.Fatalf("expected 'demo-skill' at root of skill FS after auto-detect strip (with file at root), stat error: %v", err)
+	skills, discoverErr := agentskill.Discover(s.fs)
+	if discoverErr != nil {
+		t.Fatalf("Discover: %v", discoverErr)
+	}
+	found := false
+	for _, sk := range skills {
+		if sk.Dir == "demo-skill" {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected 'demo-skill' at root of s.fs after auto-detect strip (with file at root), got: %v", skills)
+	}
+	// Verify "skills" wrapper dir was stripped.
+	if _, statErr := fs.Stat(s.fs, "skills"); statErr == nil {
+		t.Error("'skills' dir should have been stripped from root, but it still exists")
 	}
 }
 

--- a/smith_test.go
+++ b/smith_test.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"testing"
 	"testing/fstest"
+	"io/fs"
 )
 
 var testSkillFS = fstest.MapFS{
@@ -242,14 +243,8 @@ func TestNew_AutoDetect_SingleDir(t *testing.T) {
 	if err != nil {
 		t.Fatalf("New: %v", err)
 	}
-	out := &bytes.Buffer{}
-	s.OutWriter = out
-	s.ErrWriter = &bytes.Buffer{}
-	if err := s.Run(context.Background(), []string{"list"}); err != nil {
-		t.Fatalf("list: %v", err)
-	}
-	if !strings.Contains(out.String(), "demo-skill") {
-		t.Errorf("expected 'demo-skill' in list output after auto-detect strip, got: %q", out.String())
+	if _, err := fs.Stat(s.fs, "demo-skill/SKILL.md"); err != nil {
+		t.Fatalf("expected 'demo-skill' at root of skill FS after auto-detect strip, stat error: %v", err)
 	}
 }
 
@@ -260,14 +255,8 @@ func TestNew_AutoDetect_PreStripped(t *testing.T) {
 	if err != nil {
 		t.Fatalf("New: %v", err)
 	}
-	out := &bytes.Buffer{}
-	s.OutWriter = out
-	s.ErrWriter = &bytes.Buffer{}
-	if err := s.Run(context.Background(), []string{"list"}); err != nil {
-		t.Fatalf("list: %v", err)
-	}
-	if !strings.Contains(out.String(), "demo-skill") {
-		t.Errorf("expected 'demo-skill' in list output for pre-stripped FS, got: %q", out.String())
+	if _, err := fs.Stat(s.fs, "demo-skill/SKILL.md"); err != nil {
+		t.Fatalf("expected 'demo-skill' at root of pre-stripped skill FS, stat error: %v", err)
 	}
 }
 
@@ -278,14 +267,8 @@ func TestNew_AutoDetect_MixedRoot(t *testing.T) {
 	if err != nil {
 		t.Fatalf("New: %v", err)
 	}
-	out := &bytes.Buffer{}
-	s.OutWriter = out
-	s.ErrWriter = &bytes.Buffer{}
-	if err := s.Run(context.Background(), []string{"list"}); err != nil {
-		t.Fatalf("list: %v", err)
-	}
-	if !strings.Contains(out.String(), "demo-skill") {
-		t.Errorf("expected 'demo-skill' in list output for mixed-root FS, got: %q", out.String())
+	if _, err := fs.Stat(s.fs, "demo-skill/SKILL.md"); err != nil {
+		t.Fatalf("expected 'demo-skill' at root of mixed-root skill FS, stat error: %v", err)
 	}
 }
 
@@ -296,14 +279,8 @@ func TestNew_AutoDetect_SkillsDirWithFileAtRoot(t *testing.T) {
 	if err != nil {
 		t.Fatalf("New: %v", err)
 	}
-	out := &bytes.Buffer{}
-	s.OutWriter = out
-	s.ErrWriter = &bytes.Buffer{}
-	if err := s.Run(context.Background(), []string{"list"}); err != nil {
-		t.Fatalf("list: %v", err)
-	}
-	if !strings.Contains(out.String(), "demo-skill") {
-		t.Errorf("expected 'demo-skill' in list output after auto-detect strip (with file at root), got: %q", out.String())
+	if _, err := fs.Stat(s.fs, "demo-skill/SKILL.md"); err != nil {
+		t.Fatalf("expected 'demo-skill' at root of skill FS after auto-detect strip (with file at root), stat error: %v", err)
 	}
 }
 

--- a/smith_test.go
+++ b/smith_test.go
@@ -3,7 +3,6 @@ package skillsmith
 import (
 	"bytes"
 	"context"
-	"io/fs"
 	"strings"
 	"testing"
 	"testing/fstest"
@@ -26,14 +25,40 @@ Teaches the agent how to use demo.
 func newTestSmith(fsys fstest.MapFS) (*Smith, *bytes.Buffer, *bytes.Buffer) {
 	out := &bytes.Buffer{}
 	errW := &bytes.Buffer{}
-	s := &Smith{
-		FS:        fsys,
-		Version:   "v1.0.0",
-		Name:      "testtool",
-		OutWriter: out,
-		ErrWriter: errW,
+	s, err := New("testtool", "v1.0.0", fsys)
+	if err != nil {
+		panic(err)
 	}
+	s.OutWriter = out
+	s.ErrWriter = errW
 	return s, out, errW
+}
+
+func TestNew_InvalidVersion(t *testing.T) {
+	_, err := New("tool", "not-a-version", testSkillFS)
+	if err == nil {
+		t.Error("expected error for invalid version, got nil")
+	}
+}
+
+func TestNew_ValidVersion_WithV(t *testing.T) {
+	s, err := New("tool", "v1.2.3", testSkillFS)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	if s.Version() != "1.2.3" {
+		t.Errorf("expected version %q stored without 'v', got %q", "1.2.3", s.Version())
+	}
+}
+
+func TestNew_ValidVersion_WithoutV(t *testing.T) {
+	s, err := New("tool", "1.2.3", testSkillFS)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	if s.Version() != "1.2.3" {
+		t.Errorf("expected version %q stored without 'v', got %q", "1.2.3", s.Version())
+	}
 }
 
 func TestSmith_Run_UnknownSubcommand(t *testing.T) {
@@ -210,79 +235,76 @@ Teaches the agent how to use demo.
 	},
 }
 
-func TestSkillsFS_SingleDir_AutoDetects(t *testing.T) {
-	s := &Smith{FS: wrappedSkillFS}
-	detected := s.skillsFS()
-	entries, err := fs.ReadDir(detected, ".")
+// TestNew_AutoDetect_SingleDir verifies that New strips the "skills/" prefix when
+// it is the only directory at the root of skillFS.
+func TestNew_AutoDetect_SingleDir(t *testing.T) {
+	s, err := New("test", "1.0.0", wrappedSkillFS)
 	if err != nil {
-		t.Fatalf("ReadDir: %v", err)
+		t.Fatalf("New: %v", err)
 	}
-	for _, e := range entries {
-		if e.Name() == "skills" {
-			t.Error("skillsFS() should have stripped the 'skills/' prefix, but 'skills' dir still present at root")
-		}
+	out := &bytes.Buffer{}
+	s.OutWriter = out
+	s.ErrWriter = &bytes.Buffer{}
+	if err := s.Run(context.Background(), []string{"list"}); err != nil {
+		t.Fatalf("list: %v", err)
 	}
-	// demo-skill should be visible at root of the detected FS.
-	found := false
-	for _, e := range entries {
-		if e.Name() == "demo-skill" {
-			found = true
-		}
-	}
-	if !found {
-		t.Errorf("expected 'demo-skill' at root of skillsFS(), got entries: %v", entries)
+	if !strings.Contains(out.String(), "demo-skill") {
+		t.Errorf("expected 'demo-skill' in list output after auto-detect strip, got: %q", out.String())
 	}
 }
 
-func TestSkillsFS_PreStripped_UsesAsIs(t *testing.T) {
-	s := &Smith{FS: testSkillFS}
-	detected := s.skillsFS()
-	entries, err := fs.ReadDir(detected, ".")
+// TestNew_AutoDetect_PreStripped verifies that New uses the FS as-is when skills
+// are already at the root (no "skills/" prefix to strip).
+func TestNew_AutoDetect_PreStripped(t *testing.T) {
+	s, err := New("test", "1.0.0", testSkillFS)
 	if err != nil {
-		t.Fatalf("ReadDir: %v", err)
+		t.Fatalf("New: %v", err)
 	}
-	// demo-skill should be at root directly (already stripped).
-	found := false
-	for _, e := range entries {
-		if e.Name() == "demo-skill" {
-			found = true
-		}
+	out := &bytes.Buffer{}
+	s.OutWriter = out
+	s.ErrWriter = &bytes.Buffer{}
+	if err := s.Run(context.Background(), []string{"list"}); err != nil {
+		t.Fatalf("list: %v", err)
 	}
-	if !found {
-		t.Errorf("expected 'demo-skill' at root of skillsFS(), got entries: %v", entries)
+	if !strings.Contains(out.String(), "demo-skill") {
+		t.Errorf("expected 'demo-skill' in list output for pre-stripped FS, got: %q", out.String())
 	}
 }
 
-func TestSkillsFS_MixedRoot_UsesAsIs(t *testing.T) {
-	s := &Smith{FS: mixedRootFS}
-	detected := s.skillsFS()
-	// The only directory is "demo-skill" (not "skills"), so the FS is used as-is.
-	// README.md must still be visible at root.
-	if _, err := fs.Stat(detected, "README.md"); err != nil {
-		t.Errorf("expected README.md at root of skillsFS() for mixed-root FS, got: %v", err)
+// TestNew_AutoDetect_MixedRoot verifies that New uses the FS as-is when the only
+// directory at root is not named "skills".
+func TestNew_AutoDetect_MixedRoot(t *testing.T) {
+	s, err := New("test", "1.0.0", mixedRootFS)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	out := &bytes.Buffer{}
+	s.OutWriter = out
+	s.ErrWriter = &bytes.Buffer{}
+	if err := s.Run(context.Background(), []string{"list"}); err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	if !strings.Contains(out.String(), "demo-skill") {
+		t.Errorf("expected 'demo-skill' in list output for mixed-root FS, got: %q", out.String())
 	}
 }
 
-func TestSkillsFS_SkillsDirWithFileAtRoot_AutoDetects(t *testing.T) {
-	s := &Smith{FS: wrappedWithFileFS}
-	detected := s.skillsFS()
-	// Files at root (e.g. README.md) are ignored; "skills/" is still stripped.
-	entries, err := fs.ReadDir(detected, ".")
+// TestNew_AutoDetect_SkillsDirWithFileAtRoot verifies that New strips the "skills/"
+// prefix even when files are present alongside it at root.
+func TestNew_AutoDetect_SkillsDirWithFileAtRoot(t *testing.T) {
+	s, err := New("test", "1.0.0", wrappedWithFileFS)
 	if err != nil {
-		t.Fatalf("ReadDir: %v", err)
+		t.Fatalf("New: %v", err)
 	}
-	for _, e := range entries {
-		if e.Name() == "skills" {
-			t.Error("skillsFS() should have stripped the 'skills/' prefix, but 'skills' dir still present at root")
-		}
+	out := &bytes.Buffer{}
+	s.OutWriter = out
+	s.ErrWriter = &bytes.Buffer{}
+	if err := s.Run(context.Background(), []string{"list"}); err != nil {
+		t.Fatalf("list: %v", err)
 	}
-	found := false
-	for _, e := range entries {
-		if e.Name() == "demo-skill" {
-			found = true
-		}
-	}
-	if !found {
-		t.Errorf("expected 'demo-skill' at root of skillsFS(), got entries: %v", entries)
+	if !strings.Contains(out.String(), "demo-skill") {
+		t.Errorf("expected 'demo-skill' in list output after auto-detect strip (with file at root), got: %q", out.String())
 	}
 }
+
+

--- a/smith_test.go
+++ b/smith_test.go
@@ -25,12 +25,14 @@ Teaches the agent how to use demo.
 	},
 }
 
-func newTestSmith(fsys fstest.MapFS) (*Smith, *bytes.Buffer, *bytes.Buffer) {
+func newTestSmith(t *testing.T, fsys fstest.MapFS) (*Smith, *bytes.Buffer, *bytes.Buffer) {
+	t.Helper()
+
 	out := &bytes.Buffer{}
 	errW := &bytes.Buffer{}
 	s, err := New("testtool", "v1.0.0", fsys)
 	if err != nil {
-		panic(err)
+		t.Fatalf("New(%q, %q) failed: %v", "testtool", "v1.0.0", err)
 	}
 	s.OutWriter = out
 	s.ErrWriter = errW


### PR DESCRIPTION
## Overview

Add a `New(name, version string, skillFS fs.FS) (*Smith, error)` constructor. Make Smith fields private and move FS auto-detection into the constructor.

## Changes Made

- **`New` constructor**: validates version via `golang.org/x/mod/semver` (prepends `"v"` for validation only; version is stored **as provided** by the caller). Returns an error if `skillFS` is nil. Performs FS auto-detection (strips `"skills/"` prefix when it is the only directory at root). Creates `flag.NewFlagSet(name+" skills", flag.ContinueOnError)` stored as `s.FlagSet`, with `FlagSet.Usage` set up in `New` as a closure over `s`.
- **Private fields**: `FS`, `Version`, `Name`, `skillsFSOnce`, `skillsFSVal` replaced by private `name`, `version`, `fs`. `FlagSet`, `OutWriter`, `ErrWriter` remain exported.
- **`Name()` and `Version()` getters** added on `*Smith`.
- **`skillsFS()` method deleted** — logic now lives in `New`.
- **`Run` method** uses `s.FlagSet` instead of creating a new `FlagSet` internally; `Usage` is no longer re-assigned in `Run`.
- **`cmd_status.go`**: version comparison normalizes both sides with `strings.TrimPrefix("v", ...)` for compatibility with metadata written by older versions.
- **`cmd_*.go`** updated to use `s.fs`, `s.name`, `s.version`.
- **`cmd/skillsmith/main.go`** updated to use `skillsmith.New(...)`.
- **`smith_test.go`** updated: `newTestSmith` uses `New`; `TestNew_AutoDetect_*` tests assert directly on `agentskill.Discover(s.fs)` and `fs.Stat(s.fs, ...)` instead of CLI output; version validation tests use the `Version()` getter.
- **`SKETCH.md` / `README.md`** updated with `New`-based usage examples.
- **`golang.org/x/mod`** added as a dependency.

<!-- START COPILOT CODING AGENT TIPS -->
---

📍 Connect Copilot coding agent with [Jira](https://gh.io/cca-jira-docs), [Azure Boards](https://gh.io/cca-azure-boards-docs) or [Linear](https://gh.io/cca-linear-docs) to delegate work to Copilot in one click without leaving your project management tool.