### PR TITLE
Use semver for version comparison in update/reinstall

### DIFF
--- a/copy.go
+++ b/copy.go
@@ -197,11 +197,11 @@ func copySkill(src fs.FS, destDir string, skill *agentskills.Skill, opts CopyOpt
 			if cmp, ok := compareVersionsSafe(meta.Version, opts.Version); ok {
 				// Installed version is same or newer — nothing to do.
 				if cmp >= 0 {
-					return "skipped", fmt.Sprintf("skill %q is already at version %s (>= %s)", skill.Dir, meta.Version, opts.Version), nil
+					return "skipped", fmt.Sprintf("skill %q is already at version %q (>= %q)", skill.Dir, meta.Version, opts.Version), nil
 				}
 			} else if meta.Version == opts.Version {
 				// Non-semver versions: fall back to equality-only behavior.
-				return "skipped", fmt.Sprintf("skill %q is already at version %s", skill.Dir, meta.Version), nil
+				return "skipped", fmt.Sprintf("skill %q is already at version %q", skill.Dir, meta.Version), nil
 			}
 		}
 
@@ -218,7 +218,7 @@ func copySkill(src fs.FS, destDir string, skill *agentskills.Skill, opts CopyOpt
 			if readErr == nil {
 				if cmp, ok := compareVersionsSafe(meta.Version, opts.Version); ok && cmp > 0 {
 					if !opts.Force {
-						return "skipped", fmt.Sprintf("skill %q has newer version %s (> %s); use --force to downgrade", skill.Dir, meta.Version, opts.Version), nil
+						return "skipped", fmt.Sprintf("skill %q has newer version %q (> %q); use --force to downgrade", skill.Dir, meta.Version, opts.Version), nil
 					}
 				}
 			}

--- a/copy.go
+++ b/copy.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/Songmu/skillsmith/agentskills"
+	"golang.org/x/mod/semver"
 )
 
 // CopyMode controls the install/update/reinstall behavior.
@@ -140,6 +141,15 @@ func CopySkills(src fs.FS, destDir string, opts CopyOptions) (*CopyResult, error
 	return result, nil
 }
 
+// ensureVPrefix returns v with a "v" prefix, adding one if absent.
+// semver.Compare requires the "v" prefix to work correctly.
+func ensureVPrefix(v string) string {
+	if !strings.HasPrefix(v, "v") {
+		return "v" + v
+	}
+	return v
+}
+
 // copySkill handles the copy logic for a single skill directory.
 // It returns the action taken ("installed", "updated", "reinstalled", "skipped", "warned").
 func copySkill(src fs.FS, destDir string, skill *agentskills.Skill, opts CopyOptions) (action, msg string, err error) {
@@ -167,15 +177,23 @@ func copySkill(src fs.FS, destDir string, skill *agentskills.Skill, opts CopyOpt
 			return "skipped", fmt.Sprintf("skill %q is not managed by skillsmith", skill.Dir), nil
 		}
 		meta, readErr := ReadMeta(dest)
-		if readErr == nil && strings.TrimPrefix(meta.Version, "v") == strings.TrimPrefix(opts.Version, "v") {
-			// Same version — nothing to do.
-			return "skipped", fmt.Sprintf("skill %q is already at version %q", skill.Dir, opts.Version), nil
+		if readErr == nil && semver.Compare(ensureVPrefix(meta.Version), ensureVPrefix(opts.Version)) >= 0 {
+			// Installed version is same or newer — nothing to do.
+			return "skipped", fmt.Sprintf("skill %q is already at version %s (>= %s)", skill.Dir, meta.Version, opts.Version), nil
 		}
 
 	case ModeReinstall:
 		if !managed {
 			if !opts.Force {
 				return "warned", fmt.Sprintf("skill %q is not managed by skillsmith; use --force to overwrite", skill.Dir), nil
+			}
+		} else {
+			// Prevent downgrade unless --force is used.
+			meta, readErr := ReadMeta(dest)
+			if readErr == nil && semver.Compare(ensureVPrefix(meta.Version), ensureVPrefix(opts.Version)) > 0 {
+				if !opts.Force {
+					return "skipped", fmt.Sprintf("skill %q has newer version %s (> %s); use --force to downgrade", skill.Dir, meta.Version, opts.Version), nil
+				}
 			}
 		}
 	}

--- a/copy.go
+++ b/copy.go
@@ -19,6 +19,22 @@ import (
 // CopyMode controls the install/update/reinstall behavior.
 type CopyMode int
 
+// compareVersionsSafe compares two version strings using semver semantics when possible.
+// It returns (cmp, true) when both versions are valid semver after ensureVPrefix, where
+// cmp has the same meaning as semver.Compare (negative, zero, positive).
+// If either version is not a valid semver, it returns (0, false) and callers should
+// fall back to a non-semver-based behavior (typically equality-only checks).
+func compareVersionsSafe(a, b string) (int, bool) {
+	va := ensureVPrefix(a)
+	vb := ensureVPrefix(b)
+
+	if !semver.IsValid(va) || !semver.IsValid(vb) {
+		return 0, false
+	}
+
+	return semver.Compare(va, vb), true
+}
+
 const (
 	// ModeInstall installs new skills; skips existing managed skills.
 	ModeInstall CopyMode = iota
@@ -177,9 +193,16 @@ func copySkill(src fs.FS, destDir string, skill *agentskills.Skill, opts CopyOpt
 			return "skipped", fmt.Sprintf("skill %q is not managed by skillsmith", skill.Dir), nil
 		}
 		meta, readErr := ReadMeta(dest)
-		if readErr == nil && semver.Compare(ensureVPrefix(meta.Version), ensureVPrefix(opts.Version)) >= 0 {
-			// Installed version is same or newer — nothing to do.
-			return "skipped", fmt.Sprintf("skill %q is already at version %s (>= %s)", skill.Dir, meta.Version, opts.Version), nil
+		if readErr == nil {
+			if cmp, ok := compareVersionsSafe(meta.Version, opts.Version); ok {
+				// Installed version is same or newer — nothing to do.
+				if cmp >= 0 {
+					return "skipped", fmt.Sprintf("skill %q is already at version %s (>= %s)", skill.Dir, meta.Version, opts.Version), nil
+				}
+			} else if meta.Version == opts.Version {
+				// Non-semver versions: fall back to equality-only behavior.
+				return "skipped", fmt.Sprintf("skill %q is already at version %s", skill.Dir, meta.Version), nil
+			}
 		}
 
 	case ModeReinstall:
@@ -190,9 +213,11 @@ func copySkill(src fs.FS, destDir string, skill *agentskills.Skill, opts CopyOpt
 		} else {
 			// Prevent downgrade unless --force is used.
 			meta, readErr := ReadMeta(dest)
-			if readErr == nil && semver.Compare(ensureVPrefix(meta.Version), ensureVPrefix(opts.Version)) > 0 {
-				if !opts.Force {
-					return "skipped", fmt.Sprintf("skill %q has newer version %s (> %s); use --force to downgrade", skill.Dir, meta.Version, opts.Version), nil
+			if readErr == nil {
+				if cmp, ok := compareVersionsSafe(meta.Version, opts.Version); ok && cmp > 0 {
+					if !opts.Force {
+						return "skipped", fmt.Sprintf("skill %q has newer version %s (> %s); use --force to downgrade", skill.Dir, meta.Version, opts.Version), nil
+					}
 				}
 			}
 		}

--- a/copy.go
+++ b/copy.go
@@ -205,6 +205,8 @@ func copySkill(src fs.FS, destDir string, skill *agentskills.Skill, opts CopyOpt
 			}
 		}
 
+	// In reinstall mode, opts.Force controls both overwriting unmanaged skills
+	// and allowing downgrades when a newer managed version is already installed.
 	case ModeReinstall:
 		if !managed {
 			if !opts.Force {

--- a/copy_test.go
+++ b/copy_test.go
@@ -167,6 +167,31 @@ func TestCopySkills_Update_HigherVersion(t *testing.T) {
 	}
 }
 
+func TestCopySkills_Update_VersionWithoutVPrefix(t *testing.T) {
+	src := newTestFS()
+	dest := t.TempDir()
+
+	// Initial install without a leading "v" in the version string.
+	if _, err := CopySkills(src, dest, CopyOptions{Mode: ModeInstall, Name: "tool", Version: "1.0.0"}); err != nil {
+		t.Fatalf("install (no v prefix): %v", err)
+	}
+
+	// Update to a higher version, also without a leading "v".
+	result, err := CopySkills(src, dest, CopyOptions{Mode: ModeUpdate, Name: "tool", Version: "2.0.0"})
+	if err != nil {
+		t.Fatalf("update (no v prefix): %v", err)
+	}
+
+	if len(result.Installed()) != 1 || result.Installed()[0].Action != "updated" {
+		t.Errorf("expected 1 updated skill when using versions without v prefix, got: %v", result.Installed())
+	}
+
+	meta, _ := ReadMeta(filepath.Join(dest, "mytool"))
+	if meta.Version != "v2.0.0" {
+		t.Errorf("expected normalized version v2.0.0 after update, got %q", meta.Version)
+	}
+}
+
 func TestCopySkills_Update_LowerVersion(t *testing.T) {
 	src := newTestFS()
 	dest := t.TempDir()

--- a/copy_test.go
+++ b/copy_test.go
@@ -187,8 +187,8 @@ func TestCopySkills_Update_VersionWithoutVPrefix(t *testing.T) {
 	}
 
 	meta, _ := ReadMeta(filepath.Join(dest, "mytool"))
-	if meta.Version != "v2.0.0" {
-		t.Errorf("expected normalized version v2.0.0 after update, got %q", meta.Version)
+	if meta.Version != "2.0.0" {
+		t.Errorf("expected version 2.0.0 after update, got %q", meta.Version)
 	}
 }
 

--- a/copy_test.go
+++ b/copy_test.go
@@ -130,11 +130,11 @@ func TestCopySkills_Update_SameVersion(t *testing.T) {
 	src := newTestFS()
 	dest := t.TempDir()
 
-	if _, err := CopySkills(src, dest, CopyOptions{Mode: ModeInstall, Name: "tool", Version: "v1"}); err != nil {
+	if _, err := CopySkills(src, dest, CopyOptions{Mode: ModeInstall, Name: "tool", Version: "v1.0.0"}); err != nil {
 		t.Fatalf("install: %v", err)
 	}
 
-	result, err := CopySkills(src, dest, CopyOptions{Mode: ModeUpdate, Name: "tool", Version: "v1"})
+	result, err := CopySkills(src, dest, CopyOptions{Mode: ModeUpdate, Name: "tool", Version: "v1.0.0"})
 	if err != nil {
 		t.Fatalf("update: %v", err)
 	}
@@ -144,15 +144,15 @@ func TestCopySkills_Update_SameVersion(t *testing.T) {
 	}
 }
 
-func TestCopySkills_Update_DifferentVersion(t *testing.T) {
+func TestCopySkills_Update_HigherVersion(t *testing.T) {
 	src := newTestFS()
 	dest := t.TempDir()
 
-	if _, err := CopySkills(src, dest, CopyOptions{Mode: ModeInstall, Name: "tool", Version: "v1"}); err != nil {
+	if _, err := CopySkills(src, dest, CopyOptions{Mode: ModeInstall, Name: "tool", Version: "v1.0.0"}); err != nil {
 		t.Fatalf("install: %v", err)
 	}
 
-	result, err := CopySkills(src, dest, CopyOptions{Mode: ModeUpdate, Name: "tool", Version: "v2"})
+	result, err := CopySkills(src, dest, CopyOptions{Mode: ModeUpdate, Name: "tool", Version: "v2.0.0"})
 	if err != nil {
 		t.Fatalf("update: %v", err)
 	}
@@ -162,26 +162,117 @@ func TestCopySkills_Update_DifferentVersion(t *testing.T) {
 	}
 
 	meta, _ := ReadMeta(filepath.Join(dest, "mytool"))
-	if meta.Version != "v2" {
-		t.Errorf("expected version v2 after update, got %q", meta.Version)
+	if meta.Version != "v2.0.0" {
+		t.Errorf("expected version v2.0.0 after update, got %q", meta.Version)
 	}
 }
 
-func TestCopySkills_Reinstall(t *testing.T) {
+func TestCopySkills_Update_LowerVersion(t *testing.T) {
 	src := newTestFS()
 	dest := t.TempDir()
 
-	if _, err := CopySkills(src, dest, CopyOptions{Mode: ModeInstall, Name: "tool", Version: "v1"}); err != nil {
+	if _, err := CopySkills(src, dest, CopyOptions{Mode: ModeInstall, Name: "tool", Version: "v2.0.0"}); err != nil {
 		t.Fatalf("install: %v", err)
 	}
 
-	result, err := CopySkills(src, dest, CopyOptions{Mode: ModeReinstall, Name: "tool", Version: "v1"})
+	// Attempt to "update" to a lower version — should be skipped.
+	result, err := CopySkills(src, dest, CopyOptions{Mode: ModeUpdate, Name: "tool", Version: "v1.0.0"})
+	if err != nil {
+		t.Fatalf("update: %v", err)
+	}
+
+	if len(result.Skipped()) != 1 {
+		t.Errorf("expected 1 skipped skill (downgrade attempt), got: %v", result.Skipped())
+	}
+
+	// Version on disk should remain v2.0.0.
+	meta, _ := ReadMeta(filepath.Join(dest, "mytool"))
+	if meta.Version != "v2.0.0" {
+		t.Errorf("expected version to remain v2.0.0, got %q", meta.Version)
+	}
+}
+
+func TestCopySkills_Reinstall_LowerVersion_Skipped(t *testing.T) {
+	src := newTestFS()
+	dest := t.TempDir()
+
+	if _, err := CopySkills(src, dest, CopyOptions{Mode: ModeInstall, Name: "tool", Version: "v2.0.0"}); err != nil {
+		t.Fatalf("install: %v", err)
+	}
+
+	// Reinstall with lower version — should be skipped without --force.
+	result, err := CopySkills(src, dest, CopyOptions{Mode: ModeReinstall, Name: "tool", Version: "v1.0.0"})
+	if err != nil {
+		t.Fatalf("reinstall: %v", err)
+	}
+
+	if len(result.Skipped()) != 1 {
+		t.Errorf("expected 1 skipped skill (downgrade protection), got: %v", result.Skipped())
+	}
+}
+
+func TestCopySkills_Reinstall_LowerVersion_Force(t *testing.T) {
+	src := newTestFS()
+	dest := t.TempDir()
+
+	if _, err := CopySkills(src, dest, CopyOptions{Mode: ModeInstall, Name: "tool", Version: "v2.0.0"}); err != nil {
+		t.Fatalf("install: %v", err)
+	}
+
+	// Reinstall with lower version + --force — should succeed.
+	result, err := CopySkills(src, dest, CopyOptions{Mode: ModeReinstall, Name: "tool", Version: "v1.0.0", Force: true})
 	if err != nil {
 		t.Fatalf("reinstall: %v", err)
 	}
 
 	if len(result.Installed()) != 1 || result.Installed()[0].Action != "reinstalled" {
-		t.Errorf("expected 1 reinstalled skill, got: %v", result.Installed())
+		t.Errorf("expected 1 reinstalled skill with --force, got: %v", result.Installed())
+	}
+
+	meta, _ := ReadMeta(filepath.Join(dest, "mytool"))
+	if meta.Version != "v1.0.0" {
+		t.Errorf("expected version v1.0.0 after forced reinstall, got %q", meta.Version)
+	}
+}
+
+func TestCopySkills_Reinstall_SameVersion(t *testing.T) {
+	src := newTestFS()
+	dest := t.TempDir()
+
+	if _, err := CopySkills(src, dest, CopyOptions{Mode: ModeInstall, Name: "tool", Version: "v1.0.0"}); err != nil {
+		t.Fatalf("install: %v", err)
+	}
+
+	result, err := CopySkills(src, dest, CopyOptions{Mode: ModeReinstall, Name: "tool", Version: "v1.0.0"})
+	if err != nil {
+		t.Fatalf("reinstall: %v", err)
+	}
+
+	if len(result.Installed()) != 1 || result.Installed()[0].Action != "reinstalled" {
+		t.Errorf("expected 1 reinstalled skill (same version), got: %v", result.Installed())
+	}
+}
+
+func TestCopySkills_Reinstall_HigherVersion(t *testing.T) {
+	src := newTestFS()
+	dest := t.TempDir()
+
+	if _, err := CopySkills(src, dest, CopyOptions{Mode: ModeInstall, Name: "tool", Version: "v1.0.0"}); err != nil {
+		t.Fatalf("install: %v", err)
+	}
+
+	result, err := CopySkills(src, dest, CopyOptions{Mode: ModeReinstall, Name: "tool", Version: "v2.0.0"})
+	if err != nil {
+		t.Fatalf("reinstall: %v", err)
+	}
+
+	if len(result.Installed()) != 1 || result.Installed()[0].Action != "reinstalled" {
+		t.Errorf("expected 1 reinstalled skill (higher version), got: %v", result.Installed())
+	}
+
+	meta, _ := ReadMeta(filepath.Join(dest, "mytool"))
+	if meta.Version != "v2.0.0" {
+		t.Errorf("expected version v2.0.0 after reinstall, got %q", meta.Version)
 	}
 }
 


### PR DESCRIPTION
## Overview

Replace string-based version comparison with `golang.org/x/mod/semver.Compare` for correct semantic versioning.

- **update**: only update when new version is strictly higher; skip (no downgrade) when installed version is same or newer
- **reinstall**: skip if installed version is strictly newer (prevent accidental downgrade), allow with `--force`

## Implementation Details

- Added `ensureVPrefix` helper in `copy.go` that prepends `"v"` if absent, as required by `semver.Compare`
- **ModeUpdate**: uses `semver.Compare(...) >= 0` — skips when installed version is same or newer than the requested version
- **ModeReinstall**: added downgrade protection — skips if installed version is strictly newer (`> 0`), unless `--force` is used
- Added `"golang.org/x/mod/semver"` import; `"strings"` retained for `ensureVPrefix`

## Testing

Added comprehensive test cases in `copy_test.go`:
- Update with same version → skipped
- Update with higher version → updated
- Update with lower version (downgrade attempt) → skipped
- Reinstall with lower version → skipped
- Reinstall with lower version + `--force` → reinstalled
- Reinstall with same version → reinstalled
- Reinstall with higher version → reinstalled

All existing and new tests pass with `go test -race ./...`.

<!-- START COPILOT CODING AGENT TIPS -->
---

💡 You can make Copilot smarter by setting up custom instructions, customizing its development environment and configuring Model Context Protocol (MCP) servers. Learn more [Copilot coding agent tips](https://gh.io/copilot-coding-agent-tips) in the docs.