### PR TITLE
Refactor tests to table-driven style

### DIFF
--- a/agentskills/discover_test.go
+++ b/agentskills/discover_test.go
@@ -105,6 +105,7 @@ func TestDiscover_ErrorCases(t *testing.T) {
 		name           string
 		fsys           fstest.MapFS
 		wantSkillCount int
+		wantDirs       []string
 	}{
 		{
 			name: "parse_error",
@@ -119,6 +120,7 @@ description: A good skill
 				},
 			},
 			wantSkillCount: 1,
+			wantDirs:       []string{"good-skill"},
 		},
 		{
 			name: "validation_error",
@@ -146,6 +148,20 @@ description: ""
 			}
 			if len(skills) != tt.wantSkillCount {
 				t.Errorf("expected %d skill(s), got %d", tt.wantSkillCount, len(skills))
+			}
+			if len(tt.wantDirs) > 0 {
+				if len(skills) != len(tt.wantDirs) {
+					t.Fatalf("expected skills from dirs %v, but got %d skills", tt.wantDirs, len(skills))
+				}
+				gotDirs := make(map[string]struct{}, len(skills))
+				for _, s := range skills {
+					gotDirs[s.Dir] = struct{}{}
+				}
+				for _, wantDir := range tt.wantDirs {
+					if _, ok := gotDirs[wantDir]; !ok {
+						t.Errorf("expected discovered skills to include dir %q, got dirs %v", wantDir, gotDirs)
+					}
+				}
 			}
 		})
 	}

--- a/agentskills/discover_test.go
+++ b/agentskills/discover_test.go
@@ -6,141 +6,147 @@ import (
 	"testing/fstest"
 )
 
-func TestDiscover_Valid(t *testing.T) {
-	fsys := fstest.MapFS{
-		"mytool-cli/SKILL.md": {
-			Data: []byte(`---
+func TestDiscover_NormalCases(t *testing.T) {
+	tests := []struct {
+		name      string
+		fsys      fstest.MapFS
+		wantCount int
+		wantDir   string
+		wantErr   bool
+	}{
+		{
+			name: "valid_discovers_all",
+			fsys: fstest.MapFS{
+				"mytool-cli/SKILL.md": {
+					Data: []byte(`---
 name: mytool-cli
 description: A CLI skill
 license: MIT
 ---
 body
 `),
-		},
-		"other-tool/SKILL.md": {
-			Data: []byte(`---
+				},
+				"other-tool/SKILL.md": {
+					Data: []byte(`---
 name: other-tool
 description: Another skill
 ---
 `),
+				},
+			},
+			wantCount: 2,
 		},
-	}
-
-	skills, err := Discover(fsys)
-	if err != nil {
-		t.Errorf("unexpected error: %v", err)
-	}
-	if len(skills) != 2 {
-		t.Errorf("expected 2 skills, got %d", len(skills))
-	}
-}
-
-func TestDiscover_SkipsNonDirs(t *testing.T) {
-	fsys := fstest.MapFS{
-		"README.md": {Data: []byte("hello")},
-		"my-skill/SKILL.md": {
-			Data: []byte(`---
+		{
+			name: "skips_non_dirs",
+			fsys: fstest.MapFS{
+				"README.md": {Data: []byte("hello")},
+				"my-skill/SKILL.md": {
+					Data: []byte(`---
 name: my-skill
 description: A skill
 ---
 `),
+				},
+			},
+			wantCount: 1,
+			wantDir:   "my-skill",
 		},
-	}
-
-	skills, err := Discover(fsys)
-	if err != nil {
-		t.Errorf("unexpected error: %v", err)
-	}
-	if len(skills) != 1 {
-		t.Errorf("expected 1 skill, got %d", len(skills))
-	}
-	if skills[0].Dir != "my-skill" {
-		t.Errorf("Dir = %q, want %q", skills[0].Dir, "my-skill")
-	}
-}
-
-func TestDiscover_SkipsNoSKILLmd(t *testing.T) {
-	fsys := fstest.MapFS{
-		"my-skill/README.md": {Data: []byte("hello")},
-	}
-
-	skills, err := Discover(fsys)
-	if err != nil {
-		t.Errorf("unexpected error: %v", err)
-	}
-	if len(skills) != 0 {
-		t.Errorf("expected 0 skills, got %d", len(skills))
-	}
-}
-
-func TestDiscover_ParseError(t *testing.T) {
-	fsys := fstest.MapFS{
-		"bad-skill/SKILL.md": {
-			Data: []byte("no frontmatter here"),
+		{
+			name: "skips_no_skill_md",
+			fsys: fstest.MapFS{
+				"my-skill/README.md": {Data: []byte("hello")},
+			},
+			wantCount: 0,
 		},
-		"good-skill/SKILL.md": {
-			Data: []byte(`---
-name: good-skill
-description: A good skill
----
-`),
-		},
-	}
-
-	skills, err := Discover(fsys)
-	if err == nil {
-		t.Error("expected at least one error for bad-skill, got none")
-	}
-	// The error should be extractable as a SkillError.
-	var se *SkillError
-	if !errors.As(err, &se) {
-		t.Errorf("expected *SkillError in error chain, got: %T %v", err, err)
-	}
-	if len(skills) != 1 || skills[0].Dir != "good-skill" {
-		t.Errorf("expected 1 valid skill (good-skill), got %v", skills)
-	}
-}
-
-func TestDiscover_ValidationError(t *testing.T) {
-	fsys := fstest.MapFS{
-		"no-desc/SKILL.md": {
-			Data: []byte(`---
-name: no-desc
-description: ""
----
-`),
-		},
-	}
-
-	skills, err := Discover(fsys)
-	if err == nil {
-		t.Error("expected error for missing description, got none")
-	}
-	var se *SkillError
-	if !errors.As(err, &se) {
-		t.Errorf("expected *SkillError in error chain, got: %T %v", err, err)
-	}
-	if len(skills) != 0 {
-		t.Errorf("expected 0 skills, got %d", len(skills))
-	}
-}
-
-func TestDiscover_WarningDoesNotSkip(t *testing.T) {
-	fsys := fstest.MapFS{
-		"my-skill/SKILL.md": {
-			Data: []byte(`---
+		{
+			name: "warning_does_not_skip",
+			fsys: fstest.MapFS{
+				"my-skill/SKILL.md": {
+					Data: []byte(`---
 name: different-name
 description: A skill
 ---
 `),
+				},
+			},
+			wantCount: 1,
 		},
 	}
-
-	skills, err := Discover(fsys)
-	if err != nil {
-		t.Errorf("unexpected error: %v", err)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			skills, err := Discover(tt.fsys)
+			if tt.wantErr {
+				if err == nil {
+					t.Error("expected error, got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Errorf("unexpected error: %v", err)
+			}
+			if len(skills) != tt.wantCount {
+				t.Errorf("expected %d skill(s), got %d", tt.wantCount, len(skills))
+			}
+			if tt.wantDir != "" {
+				gotDir := ""
+				if len(skills) > 0 {
+					gotDir = skills[0].Dir
+				}
+				if gotDir != tt.wantDir {
+					t.Errorf("Dir = %q, want %q", gotDir, tt.wantDir)
+				}
+			}
+		})
 	}
-	if len(skills) != 1 {
-		t.Errorf("expected 1 skill (warning should not skip), got %d", len(skills))
+}
+
+func TestDiscover_ErrorCases(t *testing.T) {
+	tests := []struct {
+		name           string
+		fsys           fstest.MapFS
+		wantSkillCount int
+	}{
+		{
+			name: "parse_error",
+			fsys: fstest.MapFS{
+				"bad-skill/SKILL.md": {Data: []byte("no frontmatter here")},
+				"good-skill/SKILL.md": {
+					Data: []byte(`---
+name: good-skill
+description: A good skill
+---
+`),
+				},
+			},
+			wantSkillCount: 1,
+		},
+		{
+			name: "validation_error",
+			fsys: fstest.MapFS{
+				"no-desc/SKILL.md": {
+					Data: []byte(`---
+name: no-desc
+description: ""
+---
+`),
+				},
+			},
+			wantSkillCount: 0,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			skills, err := Discover(tt.fsys)
+			if err == nil {
+				t.Error("expected at least one error, got none")
+			}
+			var se *SkillError
+			if !errors.As(err, &se) {
+				t.Errorf("expected *SkillError in error chain, got: %T %v", err, err)
+			}
+			if len(skills) != tt.wantSkillCount {
+				t.Errorf("expected %d skill(s), got %d", tt.wantSkillCount, len(skills))
+			}
+		})
 	}
 }

--- a/agentskills/skill_test.go
+++ b/agentskills/skill_test.go
@@ -21,65 +21,36 @@ allowed_tools:
 This skill teaches AI agents how to use mytool-cli effectively.
 `
 
-func TestParse_Valid(t *testing.T) {
-	s, err := Parse(strings.NewReader(validSKILL))
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
+func TestParse_Errors(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+	}{
+		{
+			name:  "missing_opening_delimiter",
+			input: "name: foo\ndescription: bar\n",
+		},
+		{
+			name:  "missing_closing_delimiter",
+			input: "---\nname: foo\ndescription: bar\n",
+		},
+		{
+			name:  "invalid_yaml",
+			input: "---\n: invalid: yaml: [\n---\n",
+		},
 	}
-	if s.Name != "mytool-cli" {
-		t.Errorf("Name = %q, want %q", s.Name, "mytool-cli")
-	}
-	if s.Description != "A helpful CLI skill" {
-		t.Errorf("Description = %q, want %q", s.Description, "A helpful CLI skill")
-	}
-	if s.License != "MIT" {
-		t.Errorf("License = %q, want %q", s.License, "MIT")
-	}
-	if len(s.Compatibility) != 2 || s.Compatibility[0] != "claude" {
-		t.Errorf("Compatibility = %v, want [claude codex]", s.Compatibility)
-	}
-	if len(s.AllowedTools) != 1 || s.AllowedTools[0] != "Bash" {
-		t.Errorf("AllowedTools = %v, want [Bash]", s.AllowedTools)
-	}
-	if !strings.Contains(s.Body, "mytool-cli") {
-		t.Errorf("Body does not contain expected content, got: %q", s.Body)
-	}
-}
-
-func TestParse_MissingOpeningDelimiter(t *testing.T) {
-	_, err := Parse(strings.NewReader("name: foo\ndescription: bar\n"))
-	if err == nil {
-		t.Fatal("expected error, got nil")
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := Parse(strings.NewReader(tt.input))
+			if err == nil {
+				t.Fatal("expected error, got nil")
+			}
+		})
 	}
 }
 
-func TestParse_MissingClosingDelimiter(t *testing.T) {
-	_, err := Parse(strings.NewReader("---\nname: foo\ndescription: bar\n"))
-	if err == nil {
-		t.Fatal("expected error, got nil")
-	}
-}
-
-func TestParse_InvalidYAML(t *testing.T) {
-	_, err := Parse(strings.NewReader("---\n: invalid: yaml: [\n---\n"))
-	if err == nil {
-		t.Fatal("expected error for invalid YAML, got nil")
-	}
-}
-
-func TestParse_EmptyBody(t *testing.T) {
-	input := "---\nname: foo\ndescription: bar\n---\n"
-	s, err := Parse(strings.NewReader(input))
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if s.Body != "" {
-		t.Errorf("Body = %q, want empty string", s.Body)
-	}
-}
-
-func TestParse_WithMetadata(t *testing.T) {
-	input := `---
+func TestParse_Success(t *testing.T) {
+	withMetadata := `---
 name: foo
 description: bar
 metadata:
@@ -88,14 +59,64 @@ metadata:
 ---
 body
 `
-	s, err := Parse(strings.NewReader(input))
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
+	tests := []struct {
+		name      string
+		input     string
+		checkSkill func(t *testing.T, s *Skill)
+	}{
+		{
+			name:  "valid_full",
+			input: validSKILL,
+			checkSkill: func(t *testing.T, s *Skill) {
+				if s.Name != "mytool-cli" {
+					t.Errorf("Name = %q, want %q", s.Name, "mytool-cli")
+				}
+				if s.Description != "A helpful CLI skill" {
+					t.Errorf("Description = %q, want %q", s.Description, "A helpful CLI skill")
+				}
+				if s.License != "MIT" {
+					t.Errorf("License = %q, want %q", s.License, "MIT")
+				}
+				if len(s.Compatibility) != 2 || s.Compatibility[0] != "claude" {
+					t.Errorf("Compatibility = %v, want [claude codex]", s.Compatibility)
+				}
+				if len(s.AllowedTools) != 1 || s.AllowedTools[0] != "Bash" {
+					t.Errorf("AllowedTools = %v, want [Bash]", s.AllowedTools)
+				}
+				if !strings.Contains(s.Body, "mytool-cli") {
+					t.Errorf("Body does not contain expected content, got: %q", s.Body)
+				}
+			},
+		},
+		{
+			name:  "empty_body",
+			input: "---\nname: foo\ndescription: bar\n---\n",
+			checkSkill: func(t *testing.T, s *Skill) {
+				if s.Body != "" {
+					t.Errorf("Body = %q, want empty string", s.Body)
+				}
+			},
+		},
+		{
+			name:  "with_metadata",
+			input: withMetadata,
+			checkSkill: func(t *testing.T, s *Skill) {
+				if s.Metadata == nil {
+					t.Fatal("Metadata is nil, want map")
+				}
+				if s.Metadata["key"] != "value" {
+					t.Errorf("Metadata[key] = %v, want \"value\"", s.Metadata["key"])
+				}
+			},
+		},
 	}
-	if s.Metadata == nil {
-		t.Fatal("Metadata is nil, want map")
-	}
-	if s.Metadata["key"] != "value" {
-		t.Errorf("Metadata[key] = %v, want \"value\"", s.Metadata["key"])
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s, err := Parse(strings.NewReader(tt.input))
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			tt.checkSkill(t, s)
+		})
 	}
 }

--- a/agentskills/validate_test.go
+++ b/agentskills/validate_test.go
@@ -56,11 +56,11 @@ func TestValidate(t *testing.T) {
 			if result.OK() != tt.wantOK {
 				t.Errorf("OK() = %v, want %v; errors: %v", result.OK(), tt.wantOK, result.Errors)
 			}
-			if tt.wantWarnings > 0 && len(result.Warnings) == 0 {
-				t.Errorf("expected at least %d warning(s), got none", tt.wantWarnings)
+			if gotWarnings := len(result.Warnings); gotWarnings != tt.wantWarnings {
+				t.Errorf("warnings = %d, want %d; warnings: %v", gotWarnings, tt.wantWarnings, result.Warnings)
 			}
-			if tt.wantErrors > 0 && len(result.Errors) == 0 {
-				t.Errorf("expected at least %d error(s), got none", tt.wantErrors)
+			if gotErrors := len(result.Errors); gotErrors != tt.wantErrors {
+				t.Errorf("errors = %d, want %d; errors: %v", gotErrors, tt.wantErrors, result.Errors)
 			}
 		})
 	}

--- a/agentskills/validate_test.go
+++ b/agentskills/validate_test.go
@@ -1,56 +1,67 @@
 package agentskills
 
-import "testing"
+import (
+	"strings"
+	"testing"
+)
 
-func TestValidate_Valid(t *testing.T) {
-	s := &Skill{Name: "foo", Description: "some description"}
-	result := Validate(s, "foo")
-	if !result.OK() {
-		t.Errorf("expected OK, got errors: %v", result.Errors)
-	}
-	if len(result.Warnings) != 0 {
-		t.Errorf("expected no warnings, got: %v", result.Warnings)
-	}
-}
+func TestValidate(t *testing.T) {
+	longName := strings.Repeat("a", 65)
 
-func TestValidate_EmptyDescription(t *testing.T) {
-	s := &Skill{Name: "foo", Description: ""}
-	result := Validate(s, "foo")
-	if result.OK() {
-		t.Error("expected error for empty description, got OK")
+	tests := []struct {
+		name         string
+		skill        *Skill
+		dirName      string
+		wantOK       bool
+		wantWarnings int
+		wantErrors   int
+	}{
+		{
+			name:    "valid",
+			skill:   &Skill{Name: "foo", Description: "some description"},
+			dirName: "foo",
+			wantOK:  true,
+		},
+		{
+			name:       "empty_description",
+			skill:      &Skill{Name: "foo", Description: ""},
+			dirName:    "foo",
+			wantOK:     false,
+			wantErrors: 1,
+		},
+		{
+			name:         "name_mismatch",
+			skill:        &Skill{Name: "other-name", Description: "some description"},
+			dirName:      "foo",
+			wantOK:       true,
+			wantWarnings: 1,
+		},
+		{
+			name:         "name_too_long",
+			skill:        &Skill{Name: longName, Description: "some description"},
+			dirName:      longName,
+			wantOK:       true,
+			wantWarnings: 1,
+		},
+		{
+			name:    "no_name_no_dir",
+			skill:   &Skill{Name: "", Description: "desc"},
+			dirName: "",
+			wantOK:  true,
+		},
 	}
-}
-
-func TestValidate_NameMismatch(t *testing.T) {
-	s := &Skill{Name: "other-name", Description: "some description"}
-	result := Validate(s, "foo")
-	if !result.OK() {
-		t.Errorf("expected OK (name mismatch is a warning), got errors: %v", result.Errors)
-	}
-	if len(result.Warnings) == 0 {
-		t.Error("expected warning for name mismatch, got none")
-	}
-}
-
-func TestValidate_NameTooLong(t *testing.T) {
-	longName := "a"
-	for i := 0; i < 64; i++ {
-		longName += "a"
-	}
-	s := &Skill{Name: longName, Description: "some description"}
-	result := Validate(s, longName)
-	if !result.OK() {
-		t.Errorf("expected OK (long name is a warning), got errors: %v", result.Errors)
-	}
-	if len(result.Warnings) == 0 {
-		t.Error("expected warning for long name, got none")
-	}
-}
-
-func TestValidate_NoNameNoDir(t *testing.T) {
-	s := &Skill{Name: "", Description: "desc"}
-	result := Validate(s, "")
-	if !result.OK() {
-		t.Errorf("expected OK, got errors: %v", result.Errors)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := Validate(tt.skill, tt.dirName)
+			if result.OK() != tt.wantOK {
+				t.Errorf("OK() = %v, want %v; errors: %v", result.OK(), tt.wantOK, result.Errors)
+			}
+			if tt.wantWarnings > 0 && len(result.Warnings) == 0 {
+				t.Errorf("expected at least %d warning(s), got none", tt.wantWarnings)
+			}
+			if tt.wantErrors > 0 && len(result.Errors) == 0 {
+				t.Errorf("expected at least %d error(s), got none", tt.wantErrors)
+			}
+		})
 	}
 }

--- a/copy_test.go
+++ b/copy_test.go
@@ -24,280 +24,284 @@ body
 }
 
 func TestCopySkills_Install(t *testing.T) {
-	src := newTestFS()
-	dest := t.TempDir()
-
-	result, err := CopySkills(src, dest, CopyOptions{
-		Mode:    ModeInstall,
-		Name:    "tool",
-		Version: "v1.0.0",
-	})
-	if err != nil {
-		t.Fatalf("CopySkills: %v", err)
+	tests := []struct {
+		name          string
+		setup         func(t *testing.T, dest string)
+		opts          CopyOptions
+		wantInstalled int
+		wantSkipped   int
+		wantWarned    int
+		checkMeta     func(t *testing.T, dest string)
+	}{
+		{
+			name: "fresh_install",
+			opts: CopyOptions{Mode: ModeInstall, Name: "tool", Version: "v1.0.0"},
+			wantInstalled: 1,
+			checkMeta: func(t *testing.T, dest string) {
+				if _, err := os.Stat(filepath.Join(dest, "mytool", "SKILL.md")); err != nil {
+					t.Errorf("SKILL.md not found after install: %v", err)
+				}
+				if !IsManaged(filepath.Join(dest, "mytool")) {
+					t.Error(".skillsmith.json not found after install")
+				}
+				meta, err := ReadMeta(filepath.Join(dest, "mytool"))
+				if err != nil {
+					t.Fatalf("ReadMeta: %v", err)
+				}
+				if meta.InstalledBy != "tool" {
+					t.Errorf("InstalledBy = %q, want %q", meta.InstalledBy, "tool")
+				}
+				if meta.Version != "v1.0.0" {
+					t.Errorf("Version = %q, want %q", meta.Version, "v1.0.0")
+				}
+			},
+		},
+		{
+			name: "skips_existing",
+			setup: func(t *testing.T, dest string) {
+				if _, err := CopySkills(newTestFS(), dest, CopyOptions{Mode: ModeInstall, Name: "tool", Version: "v1"}); err != nil {
+					t.Fatalf("first install: %v", err)
+				}
+			},
+			opts:        CopyOptions{Mode: ModeInstall, Name: "tool", Version: "v2"},
+			wantSkipped: 1,
+			checkMeta: func(t *testing.T, dest string) {
+				meta, _ := ReadMeta(filepath.Join(dest, "mytool"))
+				if meta.Version != "v1" {
+					t.Errorf("expected version to remain v1, got %q", meta.Version)
+				}
+			},
+		},
+		{
+			name: "warns_unmanaged",
+			setup: func(t *testing.T, dest string) {
+				if err := os.MkdirAll(filepath.Join(dest, "mytool"), 0o755); err != nil {
+					t.Fatal(err)
+				}
+			},
+			opts:       CopyOptions{Mode: ModeInstall, Name: "tool", Version: "v1"},
+			wantWarned: 1,
+		},
+		{
+			name: "force_unmanaged",
+			setup: func(t *testing.T, dest string) {
+				if err := os.MkdirAll(filepath.Join(dest, "mytool"), 0o755); err != nil {
+					t.Fatal(err)
+				}
+			},
+			opts:          CopyOptions{Mode: ModeInstall, Name: "tool", Version: "v1", Force: true},
+			wantInstalled: 1,
+		},
 	}
-
-	installed := result.Installed()
-	if len(installed) != 1 || installed[0].Dir != "mytool" {
-		t.Errorf("expected 1 installed skill, got: %v", installed)
-	}
-
-	// SKILL.md should be on disk.
-	if _, err := os.Stat(filepath.Join(dest, "mytool", "SKILL.md")); err != nil {
-		t.Errorf("SKILL.md not found after install: %v", err)
-	}
-
-	// .skillsmith.json should be on disk.
-	if !IsManaged(filepath.Join(dest, "mytool")) {
-		t.Error(".skillsmith.json not found after install")
-	}
-
-	meta, err := ReadMeta(filepath.Join(dest, "mytool"))
-	if err != nil {
-		t.Fatalf("ReadMeta: %v", err)
-	}
-	if meta.InstalledBy != "tool" {
-		t.Errorf("InstalledBy = %q, want %q", meta.InstalledBy, "tool")
-	}
-	if meta.Version != "v1.0.0" {
-		t.Errorf("Version = %q, want %q", meta.Version, "v1.0.0")
-	}
-}
-
-func TestCopySkills_Install_SkipsExisting(t *testing.T) {
-	src := newTestFS()
-	dest := t.TempDir()
-
-	// First install.
-	if _, err := CopySkills(src, dest, CopyOptions{Mode: ModeInstall, Name: "tool", Version: "v1"}); err != nil {
-		t.Fatalf("first install: %v", err)
-	}
-
-	// Second install should skip.
-	result, err := CopySkills(src, dest, CopyOptions{Mode: ModeInstall, Name: "tool", Version: "v2"})
-	if err != nil {
-		t.Fatalf("second install: %v", err)
-	}
-
-	if len(result.Skipped()) != 1 {
-		t.Errorf("expected 1 skipped skill on second install, got: %v", result.Skipped())
-	}
-
-	// Version should still be v1 (not overwritten).
-	meta, _ := ReadMeta(filepath.Join(dest, "mytool"))
-	if meta.Version != "v1" {
-		t.Errorf("expected version to remain v1, got %q", meta.Version)
-	}
-}
-
-func TestCopySkills_Install_WarnsUnmanaged(t *testing.T) {
-	src := newTestFS()
-	dest := t.TempDir()
-
-	// Create an unmanaged skill directory (no .skillsmith.json).
-	if err := os.MkdirAll(filepath.Join(dest, "mytool"), 0o755); err != nil {
-		t.Fatal(err)
-	}
-
-	result, err := CopySkills(src, dest, CopyOptions{Mode: ModeInstall, Name: "tool", Version: "v1"})
-	if err != nil {
-		t.Fatalf("CopySkills: %v", err)
-	}
-
-	if len(result.Warned()) != 1 {
-		t.Errorf("expected 1 warned skill for unmanaged, got: %v", result.Warned())
-	}
-}
-
-func TestCopySkills_Install_ForceUnmanaged(t *testing.T) {
-	src := newTestFS()
-	dest := t.TempDir()
-
-	if err := os.MkdirAll(filepath.Join(dest, "mytool"), 0o755); err != nil {
-		t.Fatal(err)
-	}
-
-	result, err := CopySkills(src, dest, CopyOptions{Mode: ModeInstall, Name: "tool", Version: "v1", Force: true})
-	if err != nil {
-		t.Fatalf("CopySkills: %v", err)
-	}
-
-	if len(result.Installed()) != 1 {
-		t.Errorf("expected 1 installed skill with --force, got: %v", result.Installed())
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			src := newTestFS()
+			dest := t.TempDir()
+			if tt.setup != nil {
+				tt.setup(t, dest)
+			}
+			result, err := CopySkills(src, dest, tt.opts)
+			if err != nil {
+				t.Fatalf("CopySkills: %v", err)
+			}
+			if len(result.Installed()) != tt.wantInstalled {
+				t.Errorf("installed = %d, want %d; skills: %v", len(result.Installed()), tt.wantInstalled, result.Installed())
+			}
+			if len(result.Skipped()) != tt.wantSkipped {
+				t.Errorf("skipped = %d, want %d; skills: %v", len(result.Skipped()), tt.wantSkipped, result.Skipped())
+			}
+			if len(result.Warned()) != tt.wantWarned {
+				t.Errorf("warned = %d, want %d; skills: %v", len(result.Warned()), tt.wantWarned, result.Warned())
+			}
+			if tt.checkMeta != nil {
+				tt.checkMeta(t, dest)
+			}
+		})
 	}
 }
 
-func TestCopySkills_Update_SameVersion(t *testing.T) {
-	src := newTestFS()
-	dest := t.TempDir()
-
-	if _, err := CopySkills(src, dest, CopyOptions{Mode: ModeInstall, Name: "tool", Version: "v1.0.0"}); err != nil {
-		t.Fatalf("install: %v", err)
+func TestCopySkills_Update(t *testing.T) {
+	tests := []struct {
+		name          string
+		installVer    string
+		updateVer     string
+		wantInstalled int
+		wantAction    string
+		wantSkipped   int
+		wantVersion   string
+	}{
+		{
+			name:          "higher_version",
+			installVer:    "v1.0.0",
+			updateVer:     "v2.0.0",
+			wantInstalled: 1,
+			wantAction:    "updated",
+			wantVersion:   "v2.0.0",
+		},
+		{
+			name:        "same_version_skipped",
+			installVer:  "v1.0.0",
+			updateVer:   "v1.0.0",
+			wantSkipped: 1,
+		},
+		{
+			name:        "lower_version_skipped",
+			installVer:  "v2.0.0",
+			updateVer:   "v1.0.0",
+			wantSkipped: 1,
+			wantVersion: "v2.0.0",
+		},
+		{
+			name:          "higher_version_without_v_prefix",
+			installVer:    "1.0.0",
+			updateVer:     "2.0.0",
+			wantInstalled: 1,
+			wantAction:    "updated",
+			wantVersion:   "2.0.0",
+		},
 	}
-
-	result, err := CopySkills(src, dest, CopyOptions{Mode: ModeUpdate, Name: "tool", Version: "v1.0.0"})
-	if err != nil {
-		t.Fatalf("update: %v", err)
-	}
-
-	if len(result.Skipped()) != 1 {
-		t.Errorf("expected 1 skipped skill (same version), got: %v", result.Skipped())
-	}
-}
-
-func TestCopySkills_Update_HigherVersion(t *testing.T) {
-	src := newTestFS()
-	dest := t.TempDir()
-
-	if _, err := CopySkills(src, dest, CopyOptions{Mode: ModeInstall, Name: "tool", Version: "v1.0.0"}); err != nil {
-		t.Fatalf("install: %v", err)
-	}
-
-	result, err := CopySkills(src, dest, CopyOptions{Mode: ModeUpdate, Name: "tool", Version: "v2.0.0"})
-	if err != nil {
-		t.Fatalf("update: %v", err)
-	}
-
-	if len(result.Installed()) != 1 || result.Installed()[0].Action != "updated" {
-		t.Errorf("expected 1 updated skill, got: %v", result.Installed())
-	}
-
-	meta, _ := ReadMeta(filepath.Join(dest, "mytool"))
-	if meta.Version != "v2.0.0" {
-		t.Errorf("expected version v2.0.0 after update, got %q", meta.Version)
-	}
-}
-
-func TestCopySkills_Update_VersionWithoutVPrefix(t *testing.T) {
-	src := newTestFS()
-	dest := t.TempDir()
-
-	// Initial install without a leading "v" in the version string.
-	if _, err := CopySkills(src, dest, CopyOptions{Mode: ModeInstall, Name: "tool", Version: "1.0.0"}); err != nil {
-		t.Fatalf("install (no v prefix): %v", err)
-	}
-
-	// Update to a higher version, also without a leading "v".
-	result, err := CopySkills(src, dest, CopyOptions{Mode: ModeUpdate, Name: "tool", Version: "2.0.0"})
-	if err != nil {
-		t.Fatalf("update (no v prefix): %v", err)
-	}
-
-	if len(result.Installed()) != 1 || result.Installed()[0].Action != "updated" {
-		t.Errorf("expected 1 updated skill when using versions without v prefix, got: %v", result.Installed())
-	}
-
-	meta, _ := ReadMeta(filepath.Join(dest, "mytool"))
-	if meta.Version != "2.0.0" {
-		t.Errorf("expected version 2.0.0 after update, got %q", meta.Version)
-	}
-}
-
-func TestCopySkills_Update_LowerVersion(t *testing.T) {
-	src := newTestFS()
-	dest := t.TempDir()
-
-	if _, err := CopySkills(src, dest, CopyOptions{Mode: ModeInstall, Name: "tool", Version: "v2.0.0"}); err != nil {
-		t.Fatalf("install: %v", err)
-	}
-
-	// Attempt to "update" to a lower version — should be skipped.
-	result, err := CopySkills(src, dest, CopyOptions{Mode: ModeUpdate, Name: "tool", Version: "v1.0.0"})
-	if err != nil {
-		t.Fatalf("update: %v", err)
-	}
-
-	if len(result.Skipped()) != 1 {
-		t.Errorf("expected 1 skipped skill (downgrade attempt), got: %v", result.Skipped())
-	}
-
-	// Version on disk should remain v2.0.0.
-	meta, _ := ReadMeta(filepath.Join(dest, "mytool"))
-	if meta.Version != "v2.0.0" {
-		t.Errorf("expected version to remain v2.0.0, got %q", meta.Version)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			src := newTestFS()
+			dest := t.TempDir()
+			if _, err := CopySkills(src, dest, CopyOptions{Mode: ModeInstall, Name: "tool", Version: tt.installVer}); err != nil {
+				t.Fatalf("install: %v", err)
+			}
+			result, err := CopySkills(src, dest, CopyOptions{Mode: ModeUpdate, Name: "tool", Version: tt.updateVer})
+			if err != nil {
+				t.Fatalf("update: %v", err)
+			}
+			if len(result.Installed()) != tt.wantInstalled {
+				t.Errorf("installed = %d, want %d; skills: %v", len(result.Installed()), tt.wantInstalled, result.Installed())
+			}
+			if tt.wantAction != "" {
+				gotAction := ""
+				if len(result.Installed()) > 0 {
+					gotAction = result.Installed()[0].Action
+				}
+				if gotAction != tt.wantAction {
+					t.Errorf("action = %q, want %q", gotAction, tt.wantAction)
+				}
+			}
+			if len(result.Skipped()) != tt.wantSkipped {
+				t.Errorf("skipped = %d, want %d; skills: %v", len(result.Skipped()), tt.wantSkipped, result.Skipped())
+			}
+			if tt.wantVersion != "" {
+				meta, _ := ReadMeta(filepath.Join(dest, "mytool"))
+				if meta.Version != tt.wantVersion {
+					t.Errorf("version = %q, want %q", meta.Version, tt.wantVersion)
+				}
+			}
+		})
 	}
 }
 
-func TestCopySkills_Reinstall_LowerVersion_Skipped(t *testing.T) {
-	src := newTestFS()
-	dest := t.TempDir()
-
-	if _, err := CopySkills(src, dest, CopyOptions{Mode: ModeInstall, Name: "tool", Version: "v2.0.0"}); err != nil {
-		t.Fatalf("install: %v", err)
+func TestCopySkills_Reinstall(t *testing.T) {
+	tests := []struct {
+		name          string
+		installVer    string
+		reinstallVer  string
+		force         bool
+		wantInstalled int
+		wantAction    string
+		wantSkipped   int
+		wantWarned    int
+		wantVersion   string
+		setup         func(t *testing.T, src fstest.MapFS, dest string)
+	}{
+		{
+			name:          "same_version",
+			installVer:    "v1.0.0",
+			reinstallVer:  "v1.0.0",
+			wantInstalled: 1,
+			wantAction:    "reinstalled",
+		},
+		{
+			name:          "higher_version",
+			installVer:    "v1.0.0",
+			reinstallVer:  "v2.0.0",
+			wantInstalled: 1,
+			wantAction:    "reinstalled",
+			wantVersion:   "v2.0.0",
+		},
+		{
+			name:         "downgrade_skipped",
+			installVer:   "v2.0.0",
+			reinstallVer: "v1.0.0",
+			wantSkipped:  1,
+		},
+		{
+			name:          "force_downgrade",
+			installVer:    "v2.0.0",
+			reinstallVer:  "v1.0.0",
+			force:         true,
+			wantInstalled: 1,
+			wantAction:    "reinstalled",
+			wantVersion:   "v1.0.0",
+		},
+		{
+			name: "skips_unmanaged",
+			setup: func(t *testing.T, src fstest.MapFS, dest string) {
+				if err := os.MkdirAll(filepath.Join(dest, "mytool"), 0o755); err != nil {
+					t.Fatal(err)
+				}
+			},
+			reinstallVer: "v1.0.0",
+			wantWarned:   1,
+		},
+		{
+			name: "force_unmanaged",
+			setup: func(t *testing.T, src fstest.MapFS, dest string) {
+				if err := os.MkdirAll(filepath.Join(dest, "mytool"), 0o755); err != nil {
+					t.Fatal(err)
+				}
+			},
+			reinstallVer:  "v1.0.0",
+			force:         true,
+			wantInstalled: 1,
+			wantAction:    "reinstalled",
+		},
 	}
-
-	// Reinstall with lower version — should be skipped without --force.
-	result, err := CopySkills(src, dest, CopyOptions{Mode: ModeReinstall, Name: "tool", Version: "v1.0.0"})
-	if err != nil {
-		t.Fatalf("reinstall: %v", err)
-	}
-
-	if len(result.Skipped()) != 1 {
-		t.Errorf("expected 1 skipped skill (downgrade protection), got: %v", result.Skipped())
-	}
-}
-
-func TestCopySkills_Reinstall_LowerVersion_Force(t *testing.T) {
-	src := newTestFS()
-	dest := t.TempDir()
-
-	if _, err := CopySkills(src, dest, CopyOptions{Mode: ModeInstall, Name: "tool", Version: "v2.0.0"}); err != nil {
-		t.Fatalf("install: %v", err)
-	}
-
-	// Reinstall with lower version + --force — should succeed.
-	result, err := CopySkills(src, dest, CopyOptions{Mode: ModeReinstall, Name: "tool", Version: "v1.0.0", Force: true})
-	if err != nil {
-		t.Fatalf("reinstall: %v", err)
-	}
-
-	if len(result.Installed()) != 1 || result.Installed()[0].Action != "reinstalled" {
-		t.Errorf("expected 1 reinstalled skill with --force, got: %v", result.Installed())
-	}
-
-	meta, _ := ReadMeta(filepath.Join(dest, "mytool"))
-	if meta.Version != "v1.0.0" {
-		t.Errorf("expected version v1.0.0 after forced reinstall, got %q", meta.Version)
-	}
-}
-
-func TestCopySkills_Reinstall_SameVersion(t *testing.T) {
-	src := newTestFS()
-	dest := t.TempDir()
-
-	if _, err := CopySkills(src, dest, CopyOptions{Mode: ModeInstall, Name: "tool", Version: "v1.0.0"}); err != nil {
-		t.Fatalf("install: %v", err)
-	}
-
-	result, err := CopySkills(src, dest, CopyOptions{Mode: ModeReinstall, Name: "tool", Version: "v1.0.0"})
-	if err != nil {
-		t.Fatalf("reinstall: %v", err)
-	}
-
-	if len(result.Installed()) != 1 || result.Installed()[0].Action != "reinstalled" {
-		t.Errorf("expected 1 reinstalled skill (same version), got: %v", result.Installed())
-	}
-}
-
-func TestCopySkills_Reinstall_HigherVersion(t *testing.T) {
-	src := newTestFS()
-	dest := t.TempDir()
-
-	if _, err := CopySkills(src, dest, CopyOptions{Mode: ModeInstall, Name: "tool", Version: "v1.0.0"}); err != nil {
-		t.Fatalf("install: %v", err)
-	}
-
-	result, err := CopySkills(src, dest, CopyOptions{Mode: ModeReinstall, Name: "tool", Version: "v2.0.0"})
-	if err != nil {
-		t.Fatalf("reinstall: %v", err)
-	}
-
-	if len(result.Installed()) != 1 || result.Installed()[0].Action != "reinstalled" {
-		t.Errorf("expected 1 reinstalled skill (higher version), got: %v", result.Installed())
-	}
-
-	meta, _ := ReadMeta(filepath.Join(dest, "mytool"))
-	if meta.Version != "v2.0.0" {
-		t.Errorf("expected version v2.0.0 after reinstall, got %q", meta.Version)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			src := newTestFS()
+			dest := t.TempDir()
+			if tt.setup != nil {
+				tt.setup(t, src, dest)
+			} else if tt.installVer != "" {
+				if _, err := CopySkills(src, dest, CopyOptions{Mode: ModeInstall, Name: "tool", Version: tt.installVer}); err != nil {
+					t.Fatalf("install: %v", err)
+				}
+			}
+			result, err := CopySkills(src, dest, CopyOptions{Mode: ModeReinstall, Name: "tool", Version: tt.reinstallVer, Force: tt.force})
+			if err != nil {
+				t.Fatalf("CopySkills reinstall: %v", err)
+			}
+			if len(result.Installed()) != tt.wantInstalled {
+				t.Errorf("installed = %d, want %d; skills: %v", len(result.Installed()), tt.wantInstalled, result.Installed())
+			}
+			if tt.wantAction != "" {
+				gotAction := ""
+				if len(result.Installed()) > 0 {
+					gotAction = result.Installed()[0].Action
+				}
+				if gotAction != tt.wantAction {
+					t.Errorf("action = %q, want %q", gotAction, tt.wantAction)
+				}
+			}
+			if len(result.Skipped()) != tt.wantSkipped {
+				t.Errorf("skipped = %d, want %d; skills: %v", len(result.Skipped()), tt.wantSkipped, result.Skipped())
+			}
+			if len(result.Warned()) != tt.wantWarned {
+				t.Errorf("warned = %d, want %d; skills: %v", len(result.Warned()), tt.wantWarned, result.Warned())
+			}
+			if tt.wantVersion != "" {
+				meta, _ := ReadMeta(filepath.Join(dest, "mytool"))
+				if meta.Version != tt.wantVersion {
+					t.Errorf("version = %q, want %q", meta.Version, tt.wantVersion)
+				}
+			}
+		})
 	}
 }
 

--- a/smith_test.go
+++ b/smith_test.go
@@ -86,7 +86,9 @@ func TestNew_AutoDetect(t *testing.T) {
 		name          string
 		fsys          fstest.MapFS
 		wantSkillDir  string
-		wantSkillsDir bool // true means "skills/" should be stripped (absent from root)
+		// wantSkillsDir indicates whether a "skills/" directory should remain at the root
+		// after auto-detection. If false, "skills/" is expected to be stripped/absent.
+		wantSkillsDir bool
 		wantReadme    bool // true means README.md should be present at root
 	}{
 		{

--- a/smith_test.go
+++ b/smith_test.go
@@ -39,57 +39,154 @@ func newTestSmith(t *testing.T, fsys fstest.MapFS) (*Smith, *bytes.Buffer, *byte
 	return s, out, errW
 }
 
-func TestNew_InvalidVersion(t *testing.T) {
-	_, err := New("tool", "not-a-version", testSkillFS)
-	if err == nil {
-		t.Error("expected error for invalid version, got nil")
+func TestNew_VersionValidation(t *testing.T) {
+	tests := []struct {
+		name        string
+		version     string
+		wantErr     bool
+		wantVersion string
+	}{
+		{
+			name:    "invalid_version",
+			version: "not-a-version",
+			wantErr: true,
+		},
+		{
+			name:        "valid_with_v_prefix",
+			version:     "v1.2.3",
+			wantVersion: "v1.2.3",
+		},
+		{
+			name:        "valid_without_v_prefix",
+			version:     "1.2.3",
+			wantVersion: "1.2.3",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s, err := New("tool", tt.version, testSkillFS)
+			if tt.wantErr {
+				if err == nil {
+					t.Error("expected error, got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("New: %v", err)
+			}
+			if s.Version() != tt.wantVersion {
+				t.Errorf("Version() = %q, want %q", s.Version(), tt.wantVersion)
+			}
+		})
 	}
 }
 
-func TestNew_ValidVersion_WithV(t *testing.T) {
-	s, err := New("tool", "v1.2.3", testSkillFS)
-	if err != nil {
-		t.Fatalf("New: %v", err)
+func TestNew_AutoDetect(t *testing.T) {
+	tests := []struct {
+		name          string
+		fsys          fstest.MapFS
+		wantSkillDir  string
+		wantSkillsDir bool // true means "skills/" should be stripped (absent from root)
+		wantReadme    bool // true means README.md should be present at root
+	}{
+		{
+			name:          "single_dir_strips_skills_prefix",
+			fsys:          wrappedSkillFS,
+			wantSkillDir:  "demo-skill",
+			wantSkillsDir: false,
+		},
+		{
+			name:         "pre_stripped_uses_as_is",
+			fsys:         testSkillFS,
+			wantSkillDir: "demo-skill",
+		},
+		{
+			name:         "mixed_root_uses_as_is",
+			fsys:         mixedRootFS,
+			wantSkillDir: "demo-skill",
+			wantReadme:   true,
+		},
+		{
+			name:          "skills_dir_with_file_at_root_strips_skills",
+			fsys:          wrappedWithFileFS,
+			wantSkillDir:  "demo-skill",
+			wantSkillsDir: false,
+		},
 	}
-	if s.Version() != "v1.2.3" {
-		t.Errorf("expected version stored as-is %q, got %q", "v1.2.3", s.Version())
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s, err := New("test", "1.0.0", tt.fsys)
+			if err != nil {
+				t.Fatalf("New: %v", err)
+			}
+			skills, discoverErr := agentskills.Discover(s.fs)
+			if discoverErr != nil {
+				t.Fatalf("Discover: %v", discoverErr)
+			}
+			found := false
+			for _, sk := range skills {
+				if sk.Dir == tt.wantSkillDir {
+					found = true
+				}
+			}
+			if !found {
+				t.Errorf("expected %q in s.fs after auto-detect, got: %v", tt.wantSkillDir, skills)
+			}
+			if !tt.wantSkillsDir {
+				if _, statErr := fs.Stat(s.fs, "skills"); statErr == nil {
+					t.Error("'skills' dir should have been stripped from root, but it still exists")
+				}
+			}
+			if tt.wantReadme {
+				if _, statErr := fs.Stat(s.fs, "README.md"); statErr != nil {
+					t.Errorf("expected README.md at root of s.fs, got: %v", statErr)
+				}
+			}
+		})
 	}
 }
 
-func TestNew_ValidVersion_WithoutV(t *testing.T) {
-	s, err := New("tool", "1.2.3", testSkillFS)
-	if err != nil {
-		t.Fatalf("New: %v", err)
+func TestSmith_Run_Dispatch(t *testing.T) {
+	tests := []struct {
+		name           string
+		args           []string
+		wantErr        bool
+		wantErrOutput  string
+	}{
+		{
+			name:    "unknown_subcommand",
+			args:    []string{"unknown"},
+			wantErr: true,
+		},
+		{
+			name:    "no_args",
+			args:    []string{},
+			wantErr: false,
+		},
+		{
+			name:          "help_flag",
+			args:          []string{"--help"},
+			wantErr:       false,
+			wantErrOutput: "install",
+		},
 	}
-	if s.Version() != "1.2.3" {
-		t.Errorf("expected version %q stored without 'v', got %q", "1.2.3", s.Version())
-	}
-}
-
-func TestSmith_Run_UnknownSubcommand(t *testing.T) {
-	s, _, _ := newTestSmith(t, testSkillFS)
-	err := s.Run(context.Background(), []string{"unknown"})
-	if err == nil {
-		t.Error("expected error for unknown subcommand, got nil")
-	}
-}
-
-func TestSmith_Run_NoArgs(t *testing.T) {
-	s, _, _ := newTestSmith(t, testSkillFS)
-	err := s.Run(context.Background(), []string{})
-	if err != nil {
-		t.Errorf("unexpected error: %v", err)
-	}
-}
-
-func TestSmith_Run_Help(t *testing.T) {
-	s, _, errW := newTestSmith(t, testSkillFS)
-	err := s.Run(context.Background(), []string{"--help"})
-	if err != nil {
-		t.Errorf("unexpected error: %v", err)
-	}
-	if !strings.Contains(errW.String(), "install") {
-		t.Errorf("help output does not mention 'install', got: %q", errW.String())
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s, _, errW := newTestSmith(t, testSkillFS)
+			err := s.Run(context.Background(), tt.args)
+			if tt.wantErr {
+				if err == nil {
+					t.Error("expected error, got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Errorf("unexpected error: %v", err)
+			}
+			if tt.wantErrOutput != "" && !strings.Contains(errW.String(), tt.wantErrOutput) {
+				t.Errorf("help output does not contain %q, got: %q", tt.wantErrOutput, errW.String())
+			}
+		})
 	}
 }
 
@@ -238,104 +335,4 @@ license: MIT
 Teaches the agent how to use demo.
 `),
 	},
-}
-
-// TestNew_AutoDetect_SingleDir verifies that New strips the "skills/" prefix when
-// it is the only directory at the root of skillFS.
-func TestNew_AutoDetect_SingleDir(t *testing.T) {
-	s, err := New("test", "1.0.0", wrappedSkillFS)
-	if err != nil {
-		t.Fatalf("New: %v", err)
-	}
-	skills, discoverErr := agentskills.Discover(s.fs)
-	if discoverErr != nil {
-		t.Fatalf("Discover: %v", discoverErr)
-	}
-	found := false
-	for _, sk := range skills {
-		if sk.Dir == "demo-skill" {
-			found = true
-		}
-	}
-	if !found {
-		t.Errorf("expected 'demo-skill' at root of s.fs after auto-detect strip, got: %v", skills)
-	}
-	// Verify "skills" wrapper dir was stripped.
-	if _, statErr := fs.Stat(s.fs, "skills"); statErr == nil {
-		t.Error("'skills' dir should have been stripped from root, but it still exists")
-	}
-}
-
-// TestNew_AutoDetect_PreStripped verifies that New uses the FS as-is when skills
-// are already at the root (no "skills/" prefix to strip).
-func TestNew_AutoDetect_PreStripped(t *testing.T) {
-	s, err := New("test", "1.0.0", testSkillFS)
-	if err != nil {
-		t.Fatalf("New: %v", err)
-	}
-	skills, discoverErr := agentskills.Discover(s.fs)
-	if discoverErr != nil {
-		t.Fatalf("Discover: %v", discoverErr)
-	}
-	found := false
-	for _, sk := range skills {
-		if sk.Dir == "demo-skill" {
-			found = true
-		}
-	}
-	if !found {
-		t.Errorf("expected 'demo-skill' at root of s.fs for pre-stripped FS, got: %v", skills)
-	}
-}
-
-// TestNew_AutoDetect_MixedRoot verifies that New uses the FS as-is when the only
-// directory at root is not named "skills".
-func TestNew_AutoDetect_MixedRoot(t *testing.T) {
-	s, err := New("test", "1.0.0", mixedRootFS)
-	if err != nil {
-		t.Fatalf("New: %v", err)
-	}
-	// FS used as-is: README.md must still be present at root.
-	if _, statErr := fs.Stat(s.fs, "README.md"); statErr != nil {
-		t.Errorf("expected README.md at root of s.fs for mixed-root FS, got: %v", statErr)
-	}
-	skills, discoverErr := agentskills.Discover(s.fs)
-	if discoverErr != nil {
-		t.Fatalf("Discover: %v", discoverErr)
-	}
-	found := false
-	for _, sk := range skills {
-		if sk.Dir == "demo-skill" {
-			found = true
-		}
-	}
-	if !found {
-		t.Errorf("expected 'demo-skill' discoverable in s.fs for mixed-root FS, got: %v", skills)
-	}
-}
-
-// TestNew_AutoDetect_SkillsDirWithFileAtRoot verifies that New strips the "skills/"
-// prefix even when files are present alongside it at root.
-func TestNew_AutoDetect_SkillsDirWithFileAtRoot(t *testing.T) {
-	s, err := New("test", "1.0.0", wrappedWithFileFS)
-	if err != nil {
-		t.Fatalf("New: %v", err)
-	}
-	skills, discoverErr := agentskills.Discover(s.fs)
-	if discoverErr != nil {
-		t.Fatalf("Discover: %v", discoverErr)
-	}
-	found := false
-	for _, sk := range skills {
-		if sk.Dir == "demo-skill" {
-			found = true
-		}
-	}
-	if !found {
-		t.Errorf("expected 'demo-skill' at root of s.fs after auto-detect strip (with file at root), got: %v", skills)
-	}
-	// Verify "skills" wrapper dir was stripped.
-	if _, statErr := fs.Stat(s.fs, "skills"); statErr == nil {
-		t.Error("'skills' dir should have been stripped from root, but it still exists")
-	}
 }


### PR DESCRIPTION
## Overview

Refactor repetitive test functions into idiomatic Go table-driven tests. No behavior changes - pure test refactoring.

Targets: validate_test.go, skill_test.go, copy_test.go, smith_test.go, discover_test.go
