### PR TITLE
Fix go:embed directive and documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ With skillsmith, you can embed skill files into your Go binary using `embed.FS` 
 ## Synopsis
 
 ```go
-//go:embed skills/**
+//go:embed skills
 var skillsFS embed.FS
 
 func run(ctx context.Context, args []string) error {

--- a/SKETCH.md
+++ b/SKETCH.md
@@ -79,7 +79,7 @@ skills/
 ### 利用例
 
 ```go
-//go:embed skills/**
+//go:embed skills
 var skillsFS embed.FS
 
 func main() {

--- a/skills.go
+++ b/skills.go
@@ -5,7 +5,7 @@ import (
 	"io/fs"
 )
 
-//go:embed skills/**
+//go:embed skills
 var skillsFS embed.FS
 
 // DemoFS returns the embedded demo skills filesystem.


### PR DESCRIPTION
## Problem

The go:embed directive uses `skills/**` (double-star globstar), which is not supported by Go's embed package. The `**` pattern is not part of Go's embed specification.

## Fix

Change `//go:embed skills/**` to `//go:embed skills` (directory name only), which recursively embeds all files under `skills/`.
