### PR TITLE
Fix: use semver comparison in status command

### DIFF
--- a/cmd_status.go
+++ b/cmd_status.go
@@ -57,8 +57,9 @@ func (s *Smith) cmdStatus(_ context.Context, args []string, out, errW io.Writer)
 			continue
 		}
 
-		cmp, _ := compareVersionsSafe(meta.Version, s.version)
-		if cmp >= 0 {
+		cmp, ok := compareVersionsSafe(meta.Version, s.version)
+		upToDate := (ok && cmp >= 0) || (!ok && meta.Version == s.version)
+		if upToDate {
 			fmt.Fprintf(out, "%-30s installed %s (up to date)\n", skill.Dir, meta.Version)
 		} else {
 			fmt.Fprintf(out, "%-30s installed %s → available %s\n", skill.Dir, meta.Version, s.version)

--- a/cmd_status.go
+++ b/cmd_status.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"io"
 	"path/filepath"
-	"strings"
 
 	"github.com/Songmu/skillsmith/agentskills"
 )
@@ -58,7 +57,8 @@ func (s *Smith) cmdStatus(_ context.Context, args []string, out, errW io.Writer)
 			continue
 		}
 
-		if strings.TrimPrefix(meta.Version, "v") == strings.TrimPrefix(s.version, "v") {
+		cmp, _ := compareVersionsSafe(meta.Version, s.version)
+		if cmp >= 0 {
 			fmt.Fprintf(out, "%-30s installed %s (up to date)\n", skill.Dir, meta.Version)
 		} else {
 			fmt.Fprintf(out, "%-30s installed %s → available %s\n", skill.Dir, meta.Version, s.version)


### PR DESCRIPTION
## Bug

`cmd_status.go` uses `strings.TrimPrefix` for version comparison while `copy.go` uses `semver.Compare`. This is inconsistent and can produce wrong results for pre-release versions.
